### PR TITLE
Fixes -Wshadow and -Wsign-conversion compiler warnings.

### DIFF
--- a/Private/NSMethodSignatureForBlock.m
+++ b/Private/NSMethodSignatureForBlock.m
@@ -28,7 +28,7 @@ static NSMethodSignature *NSMethodSignatureForBlock(id block) {
         return nil;
 
     struct PMKBlockLiteral *blockRef = (__bridge struct PMKBlockLiteral *)block;
-    PMKBlockDescriptionFlags flags = blockRef->flags;
+    PMKBlockDescriptionFlags flags = (PMKBlockDescriptionFlags)blockRef->flags;
 
     if (flags & PMKBlockDescriptionFlagsHasSignature) {
         void *signatureLocation = blockRef->descriptor;

--- a/PromiseKit.m
+++ b/PromiseKit.m
@@ -198,9 +198,9 @@ static id safely_call_block(id frock, id result) {
                 return;
 
             id passme = wasarray ? ({
-                for (NSUInteger x = 0; x < results.count; ++x)
-                    if ([results pointerAtIndex:x] == (__bridge void *)PMKNull)
-                        [results replacePointerAtIndex:x withPointer:(void *)kCFNull];
+                for (NSUInteger y = 0; y < results.count; ++y)
+                    if ([results pointerAtIndex:y] == (__bridge void *)PMKNull)
+                        [results replacePointerAtIndex:y withPointer:(void *)kCFNull];
                 results.allObjects;
             }) : results.allObjects[0];
 


### PR DESCRIPTION
Fixes for two minor (trivial) warnings highlighted by our project settings. 
