### PR TITLE
Replace __anti_arc macros with objc runtime object association to keep alive for proper lifetime

### DIFF
--- a/Private/PMKManualReference.h
+++ b/Private/PMKManualReference.h
@@ -1,0 +1,6 @@
+@import Foundation.NSObject;
+
+@interface NSObject (PMKManualReference)
+- (void)pmk_reference;
+- (void)pmk_breakReference;
+@end

--- a/Private/PMKManualReference.m
+++ b/Private/PMKManualReference.m
@@ -1,0 +1,15 @@
+@import ObjectiveC.runtime;
+
+#import "PMKManualReference.h"
+
+void * PMKManualReferenceAssociatedObject = &PMKManualReferenceAssociatedObject;
+
+@implementation NSObject (PMKManualReference)
+- (void)pmk_reference {
+    objc_setAssociatedObject(self, PMKManualReferenceAssociatedObject, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void)pmk_breakReference {
+    objc_setAssociatedObject(self, PMKManualReferenceAssociatedObject, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+@end

--- a/Private/macros.m
+++ b/Private/macros.m
@@ -1,7 +1,0 @@
-#define __anti_arc_retain(...) \
-    void *retainedThing = (__bridge_retained void *)__VA_ARGS__; \
-    retainedThing = retainedThing
-#define __anti_arc_release(...) \
-    void *retainedThing = (__bridge void *) __VA_ARGS__; \
-    id unretainedThing = (__bridge_transfer id)retainedThing; \
-    unretainedThing = nil

--- a/PromiseKit+CoreLocation.m
+++ b/PromiseKit+CoreLocation.m
@@ -1,5 +1,5 @@
 @import CoreLocation.CLLocationManagerDelegate;
-#import "Private/macros.m"
+#import "Private/PMKManualReference.h"
 #import "PromiseKit+CoreLocation.h"
 #import "PromiseKit/Promise.h"
 
@@ -17,7 +17,7 @@
 #define PMKLocationManagerCleanup() \
     [manager stopUpdatingLocation]; \
     self.delegate = nil; \
-    __anti_arc_release(self);
+    [self pmk_breakReference];
 
 - (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations {
     fulfiller(PMKManifold(locations.firstObject, locations));
@@ -39,7 +39,7 @@
     PMKLocationManager *manager = [PMKLocationManager new];
     manager.delegate = manager;
     [manager startUpdatingLocation];
-    __anti_arc_retain(manager);
+    [manager pmk_reference];
     return [Promise new:^(id fulfiller, id rejecter){
         manager->fulfiller = fulfiller;
         manager->rejecter = rejecter;

--- a/PromiseKit+UIKit.m
+++ b/PromiseKit+UIKit.m
@@ -1,5 +1,5 @@
 #import <objc/runtime.h>
-#import "Private/macros.m"
+#import "Private/PMKManualReference.h"
 #import "PromiseKit/Promise.h"
 #import "PromiseKit+UIKit.h"
 @import UIKit.UINavigationController;
@@ -15,7 +15,7 @@
     else
         [controller fulfill:@(result)];
 
-    __anti_arc_release(self);
+    [self pmk_breakReference];
 }
 @end
 
@@ -30,7 +30,7 @@
     if ([vc isKindOfClass:NSClassFromString(@"MFMailComposeViewController")]) {
         PMKMFDelegater *delegater = [PMKMFDelegater new];
 
-        __anti_arc_retain(delegater);
+        [delegater pmk_reference];
 
         SEL selector = NSSelectorFromString(@"setMailComposeDelegate:");
         IMP imp = [vc methodForSelector:selector];
@@ -77,7 +77,7 @@
 @implementation PMKAlertViewDelegater
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex {
     fulfiller(PMKManifold(@(buttonIndex), alertView));
-    __anti_arc_release(self);
+    [self pmk_breakReference];
 }
 @end
 
@@ -85,7 +85,7 @@
 
 - (Promise *)promise {
     PMKAlertViewDelegater *d = [PMKAlertViewDelegater new];
-    __anti_arc_retain(d);
+    [d pmk_reference];
     self.delegate = d;
     [self show];
     return [Promise new:^(id fulfiller, id rejecter){
@@ -107,7 +107,7 @@
 @implementation PMKActionSheetDelegater
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex {
     fulfiller(PMKManifold(@(buttonIndex), actionSheet));
-    __anti_arc_release(self);
+    [self pmk_breakReference];
 }
 @end
 
@@ -115,7 +115,7 @@
 
 - (Promise *)promiseInView:(UIView *)view {
     PMKActionSheetDelegater *d = [PMKActionSheetDelegater new];
-    __anti_arc_retain(d);
+    [d pmk_reference];
     self.delegate = d;
     [self showInView:view];
     return [Promise new:^(id fulfiller, id rejecter){


### PR DESCRIPTION
If you're down with this idea, happy to create a pull request.
