### PR TITLE
Fixes mismatched selector types

### DIFF
--- a/PromiseKit.m
+++ b/PromiseKit.m
@@ -327,7 +327,7 @@ static id safely_call_block(id frock, id result) {
 
 - (id)value {
     if (IsPromise(result))
-        return [result value];
+        return [(Promise*)result value];
     if (result == PMKNull)
         return nil;
     else


### PR DESCRIPTION
Fixes error about multiple methods named 'value' found with mismatched result type.
