### PR TITLE
Fix Social extensions import in umbrella header

### DIFF
--- a/PromiseKit.h
+++ b/PromiseKit.h
@@ -11,8 +11,8 @@
 #ifdef PMK_MAPKIT
 #import "PromiseKit+MapKit.h"
 #endif
-#ifdef PMK_SOCIALFRAMEWORK
-#import "PromiseKit+SocialFramework.h"
+#ifdef PMK_SOCIAL
+#import "PromiseKit+Social.h"
 #endif
 #ifdef PMK_STOREKIT
 #import "PromiseKit+StoreKit.h"


### PR DESCRIPTION
The umbrella header `PromiseKit.h` is checking the wrong preprocessor macro and importing a non-existing header file.
