### PR TITLE
added NSJSONReadingMutableContainers in +Foundation

### DIFF
--- a/PromiseKit+Foundation.m
+++ b/PromiseKit+Foundation.m
@@ -189,7 +189,7 @@ NSString *PMKUserAgent() {
                 rejecter(err);
             } else if (NSHTTPURLResponseIsJSON(rsp)) {
                 id err = nil;
-                id json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&err];
+                id json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments|NSJSONReadingMutableContainers error:&err];
                 if (err)
                     rejecter(err);
                 else


### PR DESCRIPTION
added NSJSONReadingMutableContainers in +Foundation as NSJSONReadingAllowFragments does not appear to properly parse all valid json objects.
