### PR TITLE
Swift Example - Avoid Retain Cycle

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,7 +52,7 @@ CLLocationManager.promise().catch {
     alert.addButtonWithTitle("Bye")
     alert.addButtonWithTitle("Hi")
     return alert.promise()
-}.then { tappedButtonIndex -> Promise<Void>? in
+}.then { [unowned self] tappedButtonIndex -> Promise<Void>? in
     if tappedButtonIndex == 0 {
         return nil
     }


### PR DESCRIPTION
In the Swift example in the readme file, a Capture List could be used to avoid a retain cycle with self. Or, even better, `[weak self]` could be used, but then the if statement needs adjustments.
