### PR TITLE
Revert [NSNull null] to nil in fulfiller block

### DIFF
--- a/objc/PMKPromise.m
+++ b/objc/PMKPromise.m
@@ -44,6 +44,10 @@ static id safely_call_block(id frock, id result) {
         const NSUInteger nargs = sig.numberOfArguments;
         const char rtype = sig.methodReturnType[0];
 
+        #define null_to_nil(val) ({^id{ \
+            return (val == [NSNull null]) ? nil : val; \
+        }();})
+        
         #define call_block_with_rtype(type) ({^type{ \
             switch (nargs) { \
                 default:  @throw PMKE(@"Invalid argument count for handler block"); \
@@ -51,19 +55,19 @@ static id safely_call_block(id frock, id result) {
                 case 2: { \
                     type (^block)(id) = frock; \
                     return [result class] == [PMKArray class] \
-                        ? block(result[0]) \
+                        ? block(null_to_nil(result[0])) \
                         : block(result); \
                 } \
                 case 3: { \
                     type (^block)(id, id) = frock; \
                     return [result class] == [PMKArray class] \
-                        ? block(result[0], result[1]) \
+                        ? block(null_to_nil(result[0]), null_to_nil(result[1])) \
                         : block(result, nil); \
                 } \
                 case 4: { \
                     type (^block)(id, id, id) = frock; \
                     return [result class] == [PMKArray class] \
-                        ? block(result[0], result[1], result[2]) \
+                        ? block(null_to_nil(result[0]), null_to_nil(result[1]), null_to_nil(result[2])) \
                         : block(result, nil, nil); \
                 } \
             }}();})


### PR DESCRIPTION
We may get a "HTTP 200 OK" or other acceptable status codes from a server with no response object.
In such case we cannot set `nil` as an argument to `PMKManifold()` because it takes an `NSArray`

I just update some codes so now when we are creating a `PMKPromise`, we can write something like `fulfiller(PMKManifold([NSNull null], ...))`, and still get `nil` in `somePromise.then(^(NSDictionary *responseObject, ...) {});`.
This makes it easier to check if response object is nil or not by using `if (responseObject)` rather than `if (responseObject == [NSNull null])`.
