### PR TITLE
Changed +[PMKArray :(NSUInteger)count, ...] to +[PMKArray arrayWithCount...

### DIFF
--- a/objc/PMKPromise.m
+++ b/objc/PMKPromise.m
@@ -503,7 +503,7 @@ PMKPromise *dispatch_promise_on(dispatch_queue_t queue, id block) {
 
 @implementation PMKArray { NSUInteger count; id objs[3]; }
 
-+ (instancetype):(NSUInteger)count, ... {
++ (instancetype)arrayWithCount:(NSUInteger)count, ... {
     PMKArray *this = [self new];
     this->count = count;
     va_list args;

--- a/objc/PromiseKit/Promise.h
+++ b/objc/PromiseKit/Promise.h
@@ -105,10 +105,10 @@ Note that passing an `NSError` object is valid usage and will reject this promis
  Currently PromiseKit limits you to THREE parameters to the manifold.
 */
 #define PMKManifold(...) __PMKManifold(__VA_ARGS__, 3, 2, 1)
-#define __PMKManifold(_1, _2, _3, N, ...) [PMKArray:N, _1, _2, _3]
+#define __PMKManifold(_1, _2, _3, N, ...) [PMKArray arrayWithCount:N, _1, _2, _3]
 @interface PMKArray : NSObject
 // returning `id` to avoid compiler issues: https://github.com/mxcl/PromiseKit/issues/76
-+ (id):(NSUInteger)count, ...;
++ (id)arrayWithCount:(NSUInteger)count, ...;
 @end
 
 


### PR DESCRIPTION
I changed this to fix a crash with clang's static analyzer. The analyzer doesn't seem to like the method with no argument name.
