### PR TITLE
[NSPointerArray strongObjectsPointerArray] not available in 10.7

### DIFF
--- a/objc/PMKPromise+When.m
+++ b/objc/PMKPromise+When.m
@@ -49,7 +49,13 @@
         }];
 
     return [PMKPromise new:^(PMKPromiseFulfiller fulfiller, PMKPromiseRejecter rejecter){
-        NSPointerArray *results = [NSPointerArray strongObjectsPointerArray];
+        NSPointerArray *results = nil;
+        if ([[NSPointerArray class] respondsToSelector:@selector(strongObjectsPointerArray)]) {
+            results = [NSPointerArray strongObjectsPointerArray];
+        }
+        else if ([[NSPointerArray class] respondsToSelector:@selector(pointerArrayWithStrongObjects)]) {
+            results = [NSPointerArray pointerArrayWithStrongObjects];
+        }
         results.count = count;
 
         NSUInteger ii = 0;


### PR DESCRIPTION
I was testing out some code with PromiseKit in OS X 10.7 and ran into an issue with `strongObjectsPointerArray` which isn’t available until 10.8. As far as I can tell, pre 10.8 should use `pointerArrayWithStrongObjects` instead (which became deprecated in 10.8).

I added a switch to change the `NSPointerArray` creation method depending on `[NSPointerArray respondsToSelector:@selector(strongObjectsPointerArray)]`.
