### PR TITLE
Fix Issue with Mac Compilation

### DIFF
--- a/objc/PMKPromise+When.m
+++ b/objc/PMKPromise+When.m
@@ -50,7 +50,7 @@
 
     return [PMKPromise new:^(PMKPromiseFulfiller fulfiller, PMKPromiseRejecter rejecter){
         NSPointerArray *results = nil;
-      #ifdef TARGET_OS_IPHONE
+      #if TARGET_OS_IPHONE
         results = [NSPointerArray strongObjectsPointerArray];
       #else
         if ([[NSPointerArray class] respondsToSelector:@selector(strongObjectsPointerArray)]) {


### PR DESCRIPTION
On the Mac, TARGET_OS_IPHONE is defined (but it’s defined as 0), so this #ifdef will always resolve to true. A standard #if should be fine to switch between iOS and Mac.
