### PR TITLE
Fixed promiseSegueWithIdentifier:sender: issue

### DIFF
--- a/objc/UIViewController+PromiseKit.m
+++ b/objc/UIViewController+PromiseKit.m
@@ -63,7 +63,7 @@ static const char *kSegueRejecter = "kSegueRejecter";
 
 static void classOverridingSelector(const char* newClassPrefix, id target, SEL originalSelector, SEL overrideSelector) {
     Class klass = [target class];
-    NSString* className = NSStringFromClass(klass);
+    NSString *className = NSStringFromClass(klass);
     
     if (strncmp(newClassPrefix, [className UTF8String], strlen(newClassPrefix)) != 0) {
         NSString* subclassName = [NSString stringWithFormat:@"%s%@", newClassPrefix, className];


### PR DESCRIPTION
wouldn't allow to call an overriden prepareForSegue:sender: on a derived class.
