### PR TITLE
Reject ‘Until’ Errors

### DIFF
--- a/objc/PMKPromise+Until.m
+++ b/objc/PMKPromise+Until.m
@@ -19,6 +19,7 @@
             });
             next.catch(^(NSError *error){
                 [PMKPromise promiseWithValue:error].catch(failHandler).then(block).catch(^{
+                    reject(error);
                     block = nil;  // break retain cycle
                 });
             });


### PR DESCRIPTION
Otherwise, if you have a catch block tied to this promise, it will
never get called:

``` objc
[PMKPromise until:^PMKPromise *{
    // This will always fail
    return [PMKPromise promiseWithValue:[NSError errorWithDomain:@"asdf" code:123 userInfo:nil]];
} catch:^(NSError *error) {
    // Don't re-enter the until block
    return [PMKPromise promiseWithValue:error];
}].catch(^(NSError *error) {
    // Never executed without the fix
    NSLog(@"Error: %@", error);
});
```
