### PR TITLE
Import Foundation header

### DIFF
--- a/objc/PromiseKit/Promise+Pause.h
+++ b/objc/PromiseKit/Promise+Pause.h
@@ -1,5 +1,5 @@
 #import <PromiseKit/Promise.h>
-
+#import <Foundation/Foundation.h>
 
 @interface PMKPromise (Pause)
 


### PR DESCRIPTION
When added via Cocoapods, Promise+Pause.h failed to build as NSObject.h wasn't referenced. Adding an explicit import fixed the issue.
