### PR TITLE
If count of an object in when: is 0, then it should return an object of the same type.

### DIFF
--- a/objc/PMKPromise+When.m
+++ b/objc/PMKPromise+When.m
@@ -22,7 +22,7 @@
     __block NSUInteger count = [(id)promises count];  // FIXME
     
     if (count == 0)
-        return [PMKPromise promiseWithValue:@[]];
+        return [PMKPromise promiseWithValue:promises];
 
     // Keep a reference to the newly created
     // promise so we can check if it's resolved


### PR DESCRIPTION
The bug occurs if you pass in an empty dictionary and get an empty array back.

I have some code in my library which passes arrays and dictionaries to when:. I expect to get an object of the same type back, but it sometimes returns the wrong object. I think this is the best way of doing it, but could also create a new object of this type.

I also want to add tests, but am unable to run locally. I can't find anything in the README about contributing? Either way, fixing the bug first seems to be a good start.

``` sh
$ ./tests 
Selected tests
Test Suite 'Selected tests' passed at 2014-11-17 18:16:46 +0000.
Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
```
