### PR TITLE
Fix Xcode 6 LLVM compiler error

### DIFF
--- a/objc/UIViewController+PromiseKit.m
+++ b/objc/UIViewController+PromiseKit.m
@@ -116,7 +116,7 @@ static void classOverridingSelector(const char* newClassPrefix, id target, SEL o
         struct objc_super objcSuper;
         objcSuper.receiver = self;
         objcSuper.super_class = zuper;
-        objc_msgSendSuper(&objcSuper, prepareForSegueSelector, segue, sender);
+        ((void(*)(id, SEL, id, id))objc_msgSendSuper)((__bridge id)(&objcSuper), prepareForSegueSelector, segue, sender);
     }
 }
 


### PR DESCRIPTION
See: http://stackoverflow.com/questions/24922913/too-many-arguments-to-function-call-expected-0-have-3

By default, Xcode now enforces strict checking of objc_msgSend calls. When trying to integrate PromiseKit as a dependency for a new pod I'm creating, I was unable to compile because of this issue.