### PR TITLE
Adding Swift subspec for building PromiseKit as a Swift framework

### DIFF
--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -171,6 +171,10 @@ Pod::Spec.new do |s|
     ss.dependency 'PromiseKit/QuartzCore'
   end
 
+  s.subspec 'Swift' do |ss|
+    ss.source_files = 'swift/Sources/**/*.{swift,h,m}'
+  end
+
 #### deprecated
 
   s.subspec 'SKProductsRequest' do |ss|


### PR DESCRIPTION
Adding new "Swift" subspec so developers can install PromiseKit as a swift framework (requires 0.36 beta build of CocoaPods)

```ruby
pod 'PromiseKit/Swift', '~> 1.2'
```