### PR TITLE
Update ACAccountStore+Promise.swift

### DIFF
--- a/swift/Sources/ACAccountStore+Promise.swift
+++ b/swift/Sources/ACAccountStore+Promise.swift
@@ -13,7 +13,7 @@ extension ACAccountStore {
         }
     }
 
-    public func requestAccessToAccounts(# type: ACAccountType, options:Dictionary<String, String>? = nil) -> Promise<Void> {
+    public func requestAccessToAccounts(# type: ACAccountType, options:Dictionary<String, AnyObject>? = nil) -> Promise<Void> {
         return Promise { (fulfill, reject) in
             self.requestAccessToAccountsWithType(type, options:options) {
                 if $1 != nil {


### PR DESCRIPTION
replaced String by AnyObject in the method definition
Facebook expect an array for the permissions for example

from ACAccountStore
```swift
    // Obtains permission, if necessary, from the user to access protected properties, and utilize accounts
    // of a particular type in protected operations, for example OAuth signing. The completion handler for 
    // this method is called on an arbitrary queue.
    // Certain account types (such as Facebook) require an options dictionary. A list of the required keys
    // appears in ACAccountType.h. This method will throw an NSInvalidArgumentException if the options
    // dictionary is not provided for such account types. Conversely, if the account type does not require
    // an options dictionary, the options parameter must be nil.
    func requestAccessToAccountsWithType(accountType: ACAccountType!, options: [NSObject : AnyObject]!, completion: ACAccountStoreRequestAccessCompletionHandler!)
```