### PR TITLE
add  POST with json type equals to [String:AnyObject]

### DIFF
--- a/swift/Sources/NSURLConnection+Promise.swift
+++ b/swift/Sources/NSURLConnection+Promise.swift
@@ -168,6 +168,9 @@ extension NSURLConnection {
         return promise(OMGHTTPURLRQ.POST(url, JSON: json))
     }
 
+    public class func POST(url:String, JSON json:[String:AnyObject]) -> Promise<NSDictionary> {
+      return promise(OMGHTTPURLRQ.POST(url, JSON: json))
+    }
 
     public class func POST(url:String, multipartFormData: OMGMultipartFormData) -> Promise<NSData> {
         return promise(OMGHTTPURLRQ.POST(url, multipartFormData))


### PR DESCRIPTION
Otherwise everything is encoded as a string and we can't call the api like this 
```swift
NSURLConnection.POST(url, JSON: ["foo": 1, "bar": "..."])
```