### PR TITLE
Fix CLLocationManager.requestAlwaysAuthorization() on iOS

### DIFF
--- a/Swift Sources/CLLocationManager+Promise.swift
+++ b/Swift Sources/CLLocationManager+Promise.swift
@@ -34,7 +34,7 @@ private class AuthorizationCatcher: CLLocationManager, CLLocationManagerDelegate
         if status == .NotDetermined {
             self.delegate = self
             PMKRetain(self)
-        #if os(IOS)
+        #if os(iOS)
             requestAlwaysAuthorization()
         #endif
         } else {


### PR DESCRIPTION
Because the os() build configuration in Swift [is case sensitive](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithCAPIs.html#//apple_ref/doc/uid/TP40014216-CH8-XID_21), PromiseKit's extension to CLLocationManager does currently not work.

Changing this one line makes it work on iOS, but I wonder if there should be an else case.

Also, it seems that this issue occurs in multiple places in the source, just fixing the first occurrence I encountered.