### PR TITLE
Make LocationManager class internally visible, so that it works as CLLocationManagerDelegate

### DIFF
--- a/Swift Sources/CLLocationManager+Promise.swift
+++ b/Swift Sources/CLLocationManager+Promise.swift
@@ -1,6 +1,6 @@
 import CoreLocation.CLLocationManager
 
-private class LocationManager: CLLocationManager, CLLocationManagerDelegate {
+class LocationManager: CLLocationManager, CLLocationManagerDelegate {
     let fulfiller: ([CLLocation]) -> Void
     let rejecter: (NSError) -> Void
 


### PR DESCRIPTION
With the latest Xcode update `locationManager(manager: CLLocationManager!, didUpdateLocations locations: [AnyObject]!)` got never called in my code, until I randomly changed the class visibility from private to internal.

I think this has worked before. Sadly I was not yet able to pin down a reason why this change is necessary. (or maybe I am doing something wrong and saw the result for un unrelated reason?)