### PR TITLE
Support MFMessageComposeViewController in UIViewController+Promise

### DIFF
--- a/Swift Sources/UIViewController+Promise.swift
+++ b/Swift Sources/UIViewController+Promise.swift
@@ -84,12 +84,12 @@ extension UIViewController {
         return promiseViewController(vc, animated: animated, completion: completion)
     }
 
-    public func promiseViewController(vc: MFMailComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Any> {
+    public func promiseViewController(vc: MFMailComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<MFMailComposeResult> {
         vc.mailComposeDelegate = MFComposeViewControllerProxy()
         return promiseViewController(vc as UIViewController, animated: animated, completion: completion)
     }
 
-    public func promiseViewController(vc: MFMessageComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Any> {
+    public func promiseViewController(vc: MFMessageComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<MessageComposeResult> {
         vc.messageComposeDelegate = MFComposeViewControllerProxy()
         return promiseViewController(vc as UIViewController, animated: animated, completion: completion)
     }

--- a/Swift Sources/UIViewController+Promise.swift
+++ b/Swift Sources/UIViewController+Promise.swift
@@ -23,7 +23,7 @@ class MFComposeViewControllerProxy: NSObject, MFMailComposeViewControllerDelegat
 
     func messageComposeViewController(controller: MFMessageComposeViewController!, didFinishWithResult result: MessageComposeResult) {
         if result.value == MessageComposeResultFailed.value {
-            controller.reject(NSError(domain: PMKErrorDomain, code: 4, userInfo: [NSLocalizedDescriptionKey: "The user’s attempt to save or send the message was unsuccessful."]))
+            controller.reject(NSError(domain: PMKErrorDomain, code: PMKOperationFailed, userInfo: [NSLocalizedDescriptionKey: "The user’s attempt to save or send the message was unsuccessful."]))
         } else {
             controller.fulfill(result)
         }

--- a/Swift Sources/UIViewController+Promise.swift
+++ b/Swift Sources/UIViewController+Promise.swift
@@ -84,12 +84,12 @@ extension UIViewController {
         return promiseViewController(vc, animated: animated, completion: completion)
     }
 
-    public func promiseViewController(vc: MFMailComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Int> {
+    public func promiseViewController(vc: MFMailComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Any> {
         vc.mailComposeDelegate = MFComposeViewControllerProxy()
         return promiseViewController(vc as UIViewController, animated: animated, completion: completion)
     }
 
-    public func promiseViewController(vc: MFMessageComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Int> {
+    public func promiseViewController(vc: MFMessageComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Any> {
         vc.messageComposeDelegate = MFComposeViewControllerProxy()
         return promiseViewController(vc as UIViewController, animated: animated, completion: completion)
     }

--- a/Swift Sources/UIViewController+Promise.swift
+++ b/Swift Sources/UIViewController+Promise.swift
@@ -1,10 +1,11 @@
 import UIKit
 import MessageUI.MFMailComposeViewController
+import MessageUI.MFMessageComposeViewController
 import Social.SLComposeViewController
 import AssetsLibrary.ALAssetsLibrary
 
 
-class MFMailComposeViewControllerProxy: NSObject, MFMailComposeViewControllerDelegate, UINavigationControllerDelegate {
+class MFComposeViewControllerProxy: NSObject, MFMailComposeViewControllerDelegate, MFMessageComposeViewControllerDelegate, UINavigationControllerDelegate {
 
     override init() {
         super.init()
@@ -14,6 +15,15 @@ class MFMailComposeViewControllerProxy: NSObject, MFMailComposeViewControllerDel
     func mailComposeController(controller: MFMailComposeViewController!, didFinishWithResult result: MFMailComposeResult, error: NSError!) {
         if error != nil {
             controller.reject(error)
+        } else {
+            controller.fulfill(result)
+        }
+        PMKRelease(self)
+    }
+
+    func messageComposeViewController(controller: MFMessageComposeViewController!, didFinishWithResult result: MessageComposeResult) {
+        if result.value == MessageComposeResultFailed.value {
+            controller.reject(NSError(domain: PMKErrorDomain, code: 4, userInfo: [NSLocalizedDescriptionKey: "The user’s attempt to save or send the message was unsuccessful."]))
         } else {
             controller.fulfill(result)
         }
@@ -75,7 +85,12 @@ extension UIViewController {
     }
 
     public func promiseViewController(vc: MFMailComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Int> {
-        vc.mailComposeDelegate = MFMailComposeViewControllerProxy()
+        vc.mailComposeDelegate = MFComposeViewControllerProxy()
+        return promiseViewController(vc as UIViewController, animated: animated, completion: completion)
+    }
+
+    public func promiseViewController(vc: MFMessageComposeViewController, animated: Bool = false, completion:(Void)->() = {}) -> Promise<Int> {
+        vc.messageComposeDelegate = MFComposeViewControllerProxy()
         return promiseViewController(vc as UIViewController, animated: animated, completion: completion)
     }
 

--- a/Swift Sources/constants.swift
+++ b/Swift Sources/constants.swift
@@ -8,6 +8,7 @@ public let PMKJSONErrorJSONObjectKey = "PMKJSONErrorJSONObjectKey"
 
 public let PMKJSONError = 1
 public let NoSuchRecord = 2
+public let PMKOperationFailed = 5
 
 #if os(OSX)
 public let PMKTaskErrorStandardOutputKey = "PMKTaskErrorStandardOutputKey"

--- a/objc/PromiseKit/fwd.h
+++ b/objc/PromiseKit/fwd.h
@@ -39,6 +39,7 @@ typedef void (^PMKBooleanAdapter)(BOOL, NSError *);
 #define PMKUnknownError 2
 #define PMKInvalidUsageError 3
 #define PMKAccessDeniedError 4
+#define PMKOperationFailed 5
 
 #define PMKURLErrorFailingURLResponseKey @"PMKURLErrorFailingURLResponseKey"
 #define PMKURLErrorFailingDataKey @"PMKURLErrorFailingDataKey"

--- a/objc/UIViewController+PromiseKit.m
+++ b/objc/UIViewController+PromiseKit.m
@@ -6,13 +6,11 @@
 #import <UIKit/UINavigationController.h>
 #import <UIKit/UIImagePickerController.h>
 #import "UIViewController+PromiseKit.h"
-@import MessageUI.MFMessageComposeViewController;
-@import MessageUI.MFMailComposeViewController;
 
 static const char *kSegueFulfiller = "kSegueFulfiller";
 static const char *kSegueRejecter = "kSegueRejecter";
 
-@interface PMKMFDelegater : NSObject <MFMessageComposeViewControllerDelegate, MFMailComposeViewControllerDelegate>
+@interface PMKMFDelegater : NSObject
 @end
 
 @interface PMKUIImagePickerControllerDelegate : NSObject <UIImagePickerControllerDelegate, UINavigationControllerDelegate>
@@ -148,7 +146,7 @@ static void classOverridingSelector(const char* newClassPrefix, id target, SEL o
 
 @implementation PMKMFDelegater
 
-- (void)mailComposeController:(id)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError *)error {
+- (void)mailComposeController:(id)controller didFinishWithResult:(int)result error:(NSError *)error {
     if (error)
         [controller reject:error];
     else
@@ -157,9 +155,9 @@ static void classOverridingSelector(const char* newClassPrefix, id target, SEL o
     PMKRelease(self);
 }
 
-- (void)messageComposeViewController:(id)controller didFinishWithResult:(MessageComposeResult)result {
-    if (result == MessageComposeResultFailed)
         [controller reject:[NSError errorWithDomain:PMKErrorDomain code:PMKUnknownError userInfo:@{NSLocalizedDescriptionKey: @"The user’s attempt to save or send the message was unsuccessful."}]];
+- (void)messageComposeViewController:(id)controller didFinishWithResult:(int)result {
+    if (result == 2)
     else
         [controller fulfill:@(result)];
 

--- a/objc/UIViewController+PromiseKit.m
+++ b/objc/UIViewController+PromiseKit.m
@@ -155,9 +155,9 @@ static void classOverridingSelector(const char* newClassPrefix, id target, SEL o
     PMKRelease(self);
 }
 
-        [controller reject:[NSError errorWithDomain:PMKErrorDomain code:PMKUnknownError userInfo:@{NSLocalizedDescriptionKey: @"The user’s attempt to save or send the message was unsuccessful."}]];
 - (void)messageComposeViewController:(id)controller didFinishWithResult:(int)result {
     if (result == 2)
+        [controller reject:[NSError errorWithDomain:PMKErrorDomain code:PMKOperationFailed userInfo:@{NSLocalizedDescriptionKey: @"The user’s attempt to save or send the message was unsuccessful."}]];
     else
         [controller fulfill:@(result)];
 


### PR DESCRIPTION
Added support for promising instances of MFMessageComposeViewController and handling delegation similar to the existing support for MFMailComposeViewController. The implementations were very similar so this was a straightforward addition.

In testing the Swift counterpart I ran into issues with then'ing the result due to an attempted cast from the corresponding result type (MFMailComposeResult, MessageComposeResult) to Int. I changed the type parameter for each method's returned promise to the explicit result type to fix this issue. Due to my inexperience with Swift, I'm unsure if this is the ideal solution, but it did begin working properly after the change.