### PR TITLE
Fix when() behavior for empty array case

### DIFF
--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -10,6 +10,9 @@ private func when<T>(promises: [Promise<T>]) -> Promise<Void> {
     var progress: (completedUnitCount: Int, totalUnitCount: Int) = (0, 0)
 #endif
     var countdown = promises.count
+    if countdown == 0 {
+        fulfill()
+    }
 
     for (index, promise) in enumerate(promises) {
         promise.pipe { resolution in

--- a/Tests/CorePromise/when.test.swift
+++ b/Tests/CorePromise/when.test.swift
@@ -2,6 +2,16 @@ import XCTest
 import PromiseKit
 
 class TestWhen: XCTestCase {
+
+    func testEmpty() {
+        let e = expectationWithDescription("")
+        let promises: [Promise<Void>] = []
+        when(promises).then { _ in
+            e.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+
     func testInt() {
         let e1 = expectationWithDescription("")
         let p1 = Promise(1)


### PR DESCRIPTION
Currently, calling `when` on an empty array returns a promise that will never be resolved. This modifies it to instead return an immediately-fulfilled promise.