### PR TITLE
add geocode method that use a CLRegion

### DIFF
--- a/Categories/CoreLocation/CLGeocoder+Promise.swift
+++ b/Categories/CoreLocation/CLGeocoder+Promise.swift
@@ -35,6 +35,15 @@ extension CLGeocoder {
             }
         }
     }
+    
+  public func geocode(addressString: String, region: CLRegion) -> Promise<[CLPlacemark]> {
+    return CLPromise { sealant in
+      geocodeAddressString(addressString, inRegion: region) { placemarks, error in
+        sealant.resolve((placemarks as? [CLPlacemark]), error)
+      }
+    }
+  }
+    
 }
 
 private var onceToken: dispatch_once_t = 0


### PR DESCRIPTION
I am returning an array of CLPlacemark instead of just the first element here 
Its more convenient to get all the results for my use case, and it felt more natural not to modify the return type of the non promise api

Let me know if this works for you, otherwise I would just hard code this inside my app