### PR TITLE
Allow an array of void promises for `when`

### DIFF
--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -1,6 +1,6 @@
 import Foundation.NSProgress
 
-private func when<T>(promises: [Promise<T>]) -> Promise<Void> {
+private func _when<T>(promises: [Promise<T>]) -> Promise<Void> {
     let (rootPromise, fulfill, reject) = Promise<Void>.defer()
 #if !PMKDisableProgress
     let progress = NSProgress(totalUnitCount: Int64(promises.count))
@@ -39,7 +39,7 @@ private func when<T>(promises: [Promise<T>]) -> Promise<Void> {
 }
 
 public func when<T>(promises: [Promise<T>]) -> Promise<[T]> {
-    return when(promises).then(on: zalgo) { promises.map{ $0.value! } }
+    return _when(promises).then(on: zalgo) { promises.map{ $0.value! } }
 }
 
 public func when<T>(promises: Promise<T>...) -> Promise<[T]> {
@@ -47,15 +47,19 @@ public func when<T>(promises: Promise<T>...) -> Promise<[T]> {
 }
 
 public func when(promises: Promise<Void>...) -> Promise<Void> {
-    return when(promises)
+    return _when(promises)
+}
+
+public func when(promises: [Promise<Void>]) -> Promise<Void> {
+    return _when(promises)
 }
 
 public func when<U, V>(pu: Promise<U>, pv: Promise<V>) -> Promise<(U, V)> {
-    return when(pu.asVoid(), pv.asVoid()).then(on: zalgo) { (pu.value!, pv.value!) }
+    return _when([pu.asVoid(), pv.asVoid()]).then(on: zalgo) { (pu.value!, pv.value!) }
 }
 
 public func when<U, V, X>(pu: Promise<U>, pv: Promise<V>, px: Promise<X>) -> Promise<(U, V, X)> {
-    return when(pu.asVoid(), pv.asVoid(), px.asVoid()).then(on: zalgo) { (pu.value!, pv.value!, px.value!) }
+    return _when([pu.asVoid(), pv.asVoid(), px.asVoid()]).then(on: zalgo) { (pu.value!, pv.value!, px.value!) }
 }
 
 @availability(*, unavailable, message="Use `when`")


### PR DESCRIPTION
I have an array of void Promises (`Promise<Void>`) that I would like to use with `when`. It seems like `when` only supports void Promises when passed in as a variadic parameter.  Or maybe I am doing something wrong?  Anyways, this change allowed me to pass it in how I wanted.

```swift

var promises = [Promise<Void>]()

let promiseA: Promise<Void> = Promise { fulfiller, rejecter in
    //
}

let promiseB: Promise<Void> = Promise { fulfiller, rejecter in
    //
}

promises.append(promiseA)
promises.append(promiseB)

when(promises)
```