### PR TITLE
ABAddressBook category - return user denied state when it's already been denied

### DIFF
--- a/Categories/AddressBook/ABAddressBookRequestAccess+Promise.swift
+++ b/Categories/AddressBook/ABAddressBookRequestAccess+Promise.swift
@@ -83,10 +83,16 @@ extension NSError {
     }
 }
 
-private func ABAddressBookRequestAccess() -> Promise<(Bool, ABAddressBook)> {
+private func ABAddressBookRequestAccess() -> Promise<(Bool, ABAddressBook?)> {
     var error: Unmanaged<CFError>? = nil
     guard let ubook = ABAddressBookCreateWithOptions(nil, &error) else {
-        return Promise(error: NSError(CFError: error!.takeRetainedValue()))
+        let error = error!.takeRetainedValue()
+        if CFErrorGetCode(error) == kABOperationNotPermittedByUserError {
+            let deniedResponse: (Bool, ABAddressBook?) = (false, nil)
+            return Promise(deniedResponse)
+        }
+
+        return Promise(error: NSError(CFError: error))
     }
 
     let book: ABAddressBook = ubook.takeRetainedValue()


### PR DESCRIPTION
Currently when trying to use this category like so:

``` swift
ABAddressBookRequestAccess().then { (book: ABAddressBook) -> Void in
    // do stuff
}
.recover { error -> Void in
	let message = (error as? AddressBookError)?.localizedDescription ?? "Unknown error"

	UIAlertView(
        title: "Address book access required",
        message: message,
        delegate: nil,
        cancelButtonTitle: "OK").show()
}
```

When the application has already been denied access, The `UIAlertView` shows "Unknown error", rather than the denied message.

According to the header comments for `ABAddressBookCreateWithOptions`:
> If access to contact data is already restricted or denied, this will fail returning a NULL ABAddressBookRef with error kABOperationNotPermittedByUserError.

This change looks at the error code to ensure that it equates to `kABOperationNotPermittedByUserError`, when it does, the promise will eventually be rejected with `AddressBookError.Denied` rather than a straight up `NSError`.