### PR TITLE
add @compatibility_alias for PMKAnyPromise

### DIFF
--- a/Sources/Umbrella.h
+++ b/Sources/Umbrella.h
@@ -56,4 +56,6 @@ extern NSString * const PMKErrorDomain;
     @property (nonatomic, readonly) BOOL fulfilled;
     @property (nonatomic, readonly) BOOL rejected;
     @end
+
+    @compatibility_alias PMKAnyPromise AnyPromise;
 #endif


### PR DESCRIPTION
Wasn't able to compile a project where a Swift class returned `AnyPromise` for usage in ObjC.  

I believe the generated Swift header was the problem because it had a forward declaration for `PMKAnyPromise`, which wasn't being aliased to `AnyPromise` after importing `PromiseKit.h`.  Not sure if something in `SWIFT_CLASS` has changed, but this seems to fix it.