### PR TITLE
Fixes PMKAlertController addActionWithTitle fulfill/reject bug fix

### DIFF
--- a/Categories/UIKit/PMKAlertController.swift
+++ b/Categories/UIKit/PMKAlertController.swift
@@ -40,7 +40,7 @@ public class PMKAlertController {
 
     public func addActionWithTitle(title: String, style: UIAlertActionStyle = .Default) -> UIAlertAction {
         let action = UIAlertAction(title: title, style: style) { action in
-            if style == UIAlertActionStyle.Cancel {
+            if style != UIAlertActionStyle.Cancel {
                 self.fulfill(action)
             } else {
                 self.reject(Error.Cancelled)


### PR DESCRIPTION
Before, promises were only being fulfilled when the "Cancel" button was hit. All other button hits were triggering `self.reject()`. This is now reversed. All actions added now fulfill promises and the Cancel button triggers `self.reject()`. 1 character change.