### PR TITLE
added missing defines causing crash when using @objc

### DIFF
--- a/Sources/Umbrella.h
+++ b/Sources/Umbrella.h
@@ -43,9 +43,11 @@ extern NSString * const PMKErrorDomain;
     #endif
     #if !defined(SWIFT_CLASS)
     # if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
-    #  define SWIFT_CLASS(SWIFT_NAME) SWIFT_RUNTIME_NAME(SWIFT_NAME) __attribute__((objc_subclassing_restricted)) SWIFT_CLASS_EXTRA
+	#  define SWIFT_CLASS(SWIFT_NAME) SWIFT_RUNTIME_NAME(SWIFT_NAME) __attribute__((objc_subclassing_restricted)) SWIFT_CLASS_EXTRA
+	#  define SWIFT_CLASS_NAMED(SWIFT_NAME) __attribute__((objc_subclassing_restricted)) SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_CLASS_EXTRA
     # else
-    #  define SWIFT_CLASS(SWIFT_NAME) SWIFT_RUNTIME_NAME(SWIFT_NAME) SWIFT_CLASS_EXTRA
+	#  define SWIFT_CLASS(SWIFT_NAME) SWIFT_RUNTIME_NAME(SWIFT_NAME) SWIFT_CLASS_EXTRA
+	#  define SWIFT_CLASS_NAMED(SWIFT_NAME) SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_CLASS_EXTRA
     # endif
     #endif
 


### PR DESCRIPTION
PromiseKit breaks @objc(ClassName) swift modifier because of redefined SWIFT_MACRO in PromiseKit.

* PromiseKit redefines SWIFT_CLASS but not SWIFT_CLASS_NAMED
* Project-Swift.h checks defined(SWIFT_CLASS) before defining both
* So if PromiseKit is imported before Project-Swift.h (as instructed), SWIFT_CLASS_NAMED never gets defined.

The commit fixes the issue.