### PR TITLE
NSError. cancelledError() needs to be public for Swift

### DIFF
--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -95,7 +95,7 @@ private func ==(lhs: ErrorPair, rhs: ErrorPair) -> Bool {
 }
 
 extension NSError {
-    @objc class func cancelledError() -> NSError {
+    @objc public class func cancelledError() -> NSError {
         let info: [NSObject: AnyObject] = [NSLocalizedDescriptionKey: "The operation was cancelled"]
         return NSError(domain: PMKErrorDomain, code: PMKOperationCancelled, userInfo: info)
     }


### PR DESCRIPTION
NSError.cancelledError() wasn’t available from Swift code