### PR TITLE
Add EventKit request access promise

### DIFF
--- a/Categories/EventKit/EKEventStore+Promise.swift
+++ b/Categories/EventKit/EKEventStore+Promise.swift
@@ -1,0 +1,67 @@
+//
+//  EKEventStore+Promise.swift
+//  PromiseKit
+//
+//  Created by Lammert Westerhoff on 16/02/16.
+//  Copyright © 2016 Max Howell. All rights reserved.
+//
+
+import CoreFoundation
+import Foundation.NSError
+import EventKit
+
+#if !COCOAPODS
+    import PromiseKit
+#endif
+
+public enum EventKitError: ErrorType {
+    case Restricted
+    case Denied
+
+    public var localizedDescription: String {
+        switch self {
+        case .Restricted:
+            return "A head of family must grant calendar access."
+        case .Denied:
+            return "Calendar access has been denied."
+        }
+    }
+}
+
+/**
+ Requests access to the event store.
+
+ To import `EKEventStore`:
+
+ use_frameworks!
+ pod "PromiseKit/EventKit"
+
+ And then in your sources:
+
+ import PromiseKit
+
+ @return A promise that fulfills with the EKEventStore.
+ */
+public func EKEventStoreRequestAccess() -> Promise<(EKEventStore)> {
+    let eventStore = EKEventStore()
+    return Promise { fulfill, reject in
+
+        let authorization = EKEventStore.authorizationStatusForEntityType(EKEntityType.Event)
+        switch authorization {
+        case .Authorized:
+            fulfill(eventStore)
+        case .Denied:
+            reject(EventKitError.Denied)
+        case .Restricted:
+            reject(EventKitError.Restricted)
+        case .NotDetermined:
+            eventStore.requestAccessToEntityType(EKEntityType.Event) { granted, error in
+                if granted {
+                    fulfill(eventStore)
+                } else {
+                    reject(EventKitError.Denied)
+                }
+            }
+        }
+    }
+}

--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -80,6 +80,12 @@ Pod::Spec.new do |s|
     ss.dependency 'PromiseKit/CorePromise'
     ss.frameworks = 'CoreLocation'
   end
+
+  s.subspec 'EventKit' do |ss|
+    ss.ios.source_files = 'Categories/EventKit/*'
+    ss.dependency 'PromiseKit/CorePromise'
+    ss.ios.frameworks = 'EventKit'
+  end
   
   s.subspec 'Foundation' do |ss|
     ss.ios.source_files = Dir['Categories/Foundation/*'] - Dir['Categories/Foundation/NSTask*']

--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F0BAE0C1C901E9300A4DCA1 /* TestEventKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0BAE0B1C901E9300A4DCA1 /* TestEventKit.swift */; };
 		2F814F131C73A8C800ABF4D1 /* EKEventStore+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F814F111C73782100ABF4D1 /* EKEventStore+Promise.swift */; };
 		43EF78B41C5AB88600BCD8FB /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A60E1F1AFD795B00C4E692 /* after.m */; };
 		43EF78B51C5AB88600BCD8FB /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63075EBD1AD0EDB3002C46A0 /* after.swift */; };
@@ -358,6 +359,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2F0BAE0B1C901E9300A4DCA1 /* TestEventKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEventKit.swift; sourceTree = "<group>"; };
 		2F814F111C73782100ABF4D1 /* EKEventStore+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EKEventStore+Promise.swift"; sourceTree = "<group>"; };
 		43EF78A61C5AA12B00BCD8FB /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6302AC8E1AEF42F2001F0069 /* ACAccountStore+AnyPromise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ACAccountStore+AnyPromise.h"; sourceTree = "<group>"; };
@@ -1022,6 +1024,7 @@
 				63DF16F71AEAC46E00BE97DD /* TestAVFoundation.swift */,
 				63DF16F91AEAC46E00BE97DD /* TestCloudKit.swift */,
 				63DF16FB1AEAC46E00BE97DD /* TestCoreLocation.swift */,
+				2F0BAE0B1C901E9300A4DCA1 /* TestEventKit.swift */,
 				63DF17031AEAC46E00BE97DD /* TestMessageUI.m */,
 				638AF9661B62B7DE0045C3E8 /* TestMessageUI.swift */,
 				6391FD2C1B62ED7D00671798 /* TestFoundation */,
@@ -1534,6 +1537,7 @@
 				638AF8E11B62B1AF0045C3E8 /* MKMapSnapshotter+Promise.swift in Sources */,
 				638AF8E21B62B1AF0045C3E8 /* MFMailComposeViewController+Promise.swift in Sources */,
 				638AF8E31B62B1AF0045C3E8 /* MFMessageComposeViewController+Promise.swift in Sources */,
+				2F0BAE0C1C901E9300A4DCA1 /* TestEventKit.swift in Sources */,
 				638AF8E41B62B1AF0045C3E8 /* PHPhotoLibrary+Promise.swift in Sources */,
 				638AF8E61B62B1AF0045C3E8 /* CALayer+AnyPromise.m in Sources */,
 				638AF8E71B62B1AF0045C3E8 /* SLComposeViewController+Promise.swift in Sources */,

--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F814F131C73A8C800ABF4D1 /* EKEventStore+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F814F111C73782100ABF4D1 /* EKEventStore+Promise.swift */; };
 		43EF78B41C5AB88600BCD8FB /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A60E1F1AFD795B00C4E692 /* after.m */; };
 		43EF78B51C5AB88600BCD8FB /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63075EBD1AD0EDB3002C46A0 /* after.swift */; };
 		43EF78B61C5AB88600BCD8FB /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A157711ABB59D00002A421 /* AnyPromise.m */; };
@@ -357,6 +358,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2F814F111C73782100ABF4D1 /* EKEventStore+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EKEventStore+Promise.swift"; sourceTree = "<group>"; };
 		43EF78A61C5AA12B00BCD8FB /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6302AC8E1AEF42F2001F0069 /* ACAccountStore+AnyPromise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ACAccountStore+AnyPromise.h"; sourceTree = "<group>"; };
 		6302AC8F1AEF42F2001F0069 /* ACAccountStore+AnyPromise.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ACAccountStore+AnyPromise.m"; sourceTree = "<group>"; };
@@ -599,6 +601,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2F814F101C73779800ABF4D1 /* EventKit */ = {
+			isa = PBXGroup;
+			children = (
+				2F814F111C73782100ABF4D1 /* EKEventStore+Promise.swift */,
+			);
+			path = EventKit;
+			sourceTree = "<group>";
+		};
 		43EA5FF21C5AC38C000BAEA7 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -911,6 +921,7 @@
 				63D1BA9D1B256DE500435BF3 /* Bolts */,
 				6302AC991AEF42F2001F0069 /* CloudKit */,
 				6302ACA01AEF42F2001F0069 /* CoreLocation */,
+				2F814F101C73779800ABF4D1 /* EventKit */,
 				6302ACA71AEF42F2001F0069 /* Foundation */,
 				6302ACB21AEF42F2001F0069 /* MapKit */,
 				6302ACB91AEF42F2001F0069 /* MessageUI */,
@@ -1556,6 +1567,7 @@
 				638AF9561B62B7230045C3E8 /* TestMapKit.swift in Sources */,
 				638AF9571B62B7230045C3E8 /* TestQuartzCore.m in Sources */,
 				638AF95A1B62B7230045C3E8 /* TestSocial.m in Sources */,
+				2F814F131C73A8C800ABF4D1 /* EKEventStore+Promise.swift in Sources */,
 				638AF95B1B62B7230045C3E8 /* TestSocial.swift in Sources */,
 				638AF95C1B62B7230045C3E8 /* TestStoreKit.m in Sources */,
 				638AF95D1B62B7230045C3E8 /* TestStoreKit.swift in Sources */,

--- a/Tests/TestEventKit.swift
+++ b/Tests/TestEventKit.swift
@@ -1,0 +1,14 @@
+import EventKit
+import Foundation
+import PromiseKit
+import XCTest
+
+class Test_EventKit_Swift: XCTestCase {
+    func test() {
+        let ex = expectationWithDescription("")
+        EKEventStoreRequestAccess().then { _ in
+            ex.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+}


### PR DESCRIPTION
This pull request adds a public function EKEventStoreRequestAccess to get access to EventKit to add events to the user's calendar. Example usage:

    func addEvent() {
        EKEventStoreRequestAccess().then { eventStore in
            let event = EKEvent(eventStore: eventStore)
            event.calendar = eventStore.defaultCalendarForNewEvents
            event.title = "My event"

            let editEventController = EKEventEditViewController(nibName: nil, bundle: nil)

            editEventController.event = event
            editEventController.eventStore = eventStore
            
            self.presentViewController(editEventController, animated: true, completion: nil)
        }
    }