### PR TITLE
Give a typealias for pendingPromise result.

### DIFF
--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -193,9 +193,9 @@ public class Promise<T> {
        2) A function that fulfills that promise
        3) A function that rejects that promise
     */
-    public typealias ExpandedPromise = (promise: Promise, fulfill: (T) -> Void, reject: (ErrorType) -> Void)
+    public typealias PendingPromise = (promise: Promise, fulfill: (T) -> Void, reject: (ErrorType) -> Void)
     
-    public class func pendingPromise() -> ExpandedPromise {
+    public class func pendingPromise() -> PendingPromise {
         var fulfill: ((T) -> Void)!
         var reject: ((ErrorType) -> Void)!
         let promise = Promise { fulfill = $0; reject = $1 }

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -193,7 +193,9 @@ public class Promise<T> {
        2) A function that fulfills that promise
        3) A function that rejects that promise
     */
-    public class func pendingPromise() -> (promise: Promise, fulfill: (T) -> Void, reject: (ErrorType) -> Void) {
+    public typealias ExpandedPromise = (promise: Promise, fulfill: (T) -> Void, reject: (ErrorType) -> Void)
+    
+    public class func pendingPromise() -> ExpandedPromise {
         var fulfill: ((T) -> Void)!
         var reject: ((ErrorType) -> Void)!
         let promise = Promise { fulfill = $0; reject = $1 }


### PR DESCRIPTION
I had to declare a variable to hold the result of a pendingPromise call and the type declaration is very long. This will make it a little easier to type... Not sure about the name `ExpandedPromise` though. Maybe it should be `PendingPromise`?