### PR TITLE
Header fix for issue #377.

### DIFF
--- a/Sources/PromiseKit.h
+++ b/Sources/PromiseKit.h
@@ -1,4 +1,8 @@
-#import <dispatch/queue.h>
+#if defined(__cplusplus)
+  #import <dispatch/dispatch.h>
+#else
+  #import <dispatch/queue.h>
+#endif
 #import <Foundation/NSDate.h>
 #import <Foundation/NSObject.h>
 #import <PromiseKit/AnyPromise.h>


### PR DESCRIPTION
Pull request that addresses issue  #377. 

In response to https://github.com/mxcl/PromiseKit/issues/377#issuecomment-196921790 I've implemented the fix that will conditionally import `<dispatch/dispatch.h>` for Objective-C++ projects, while still only import `<dispatch/queue.h>` for vanilla Objective-C projects.  