### PR TITLE
Downcasting AnyPromise to Promise<T> using .toPromise(T)

### DIFF
--- a/Sources/AnyPromise.swift
+++ b/Sources/AnyPromise.swift
@@ -213,6 +213,20 @@ import Foundation.NSError
         })
     }
 
+    /**
+     - Returns: downcasted (typed) `Promise<T>`.
+     Throws `CastingError.CastingAnyPromiseFailed(T)` if self's value cannot be downcasted to the given type.
+     Usage: `anyPromise.toPromise(T).then { (t: T) -> U in ... }`
+    */
+    public func toPromise<T>(type: T.Type) -> Promise<T> {
+        return self.then { (value: AnyObject?) -> T in
+            if let value = value as? T {
+                return value
+            }
+            throw CastingError.CastingAnyPromiseFailed(type)
+        }
+    }
+
     private class State: UnsealedState<AnyObject?> {
         required init(inout resolver: ((AnyObject?) -> Void)!) {
             var preresolve: ((AnyObject?) -> Void)!

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -77,6 +77,10 @@ public enum JSONError: ErrorType {
     case UnexpectedRootNode(AnyObject)
 }
 
+public enum CastingError: ErrorType {
+    case CastingAnyPromiseFailed(Any.Type)
+}
+
 
 //////////////////////////////////////////////////////////// Cancellation
 private struct ErrorPair: Hashable {


### PR DESCRIPTION
The motivation behind this addition is described here: https://github.com/mxcl/PromiseKit/issues/388

When working with legacy ObjC parts returning `AnyPromises`, it's nice to have an option to convert to a typed `Promise<T>`. This PR enables just this:

```swift
LegacyBackend.fetchUser()   // AnyPromise
.toPromise(User)            // Promise<User>
.then { user in
    // Now we can work with user: User
}
```

I found this very useful when working with large chunks of ObjC code that is otherwise fine and isn't worthy of rewriting to Swift just to get the typed promises.

When the downcasting fails, an error is thrown.