### PR TITLE
Fix when dismissing a promiseViewController

### DIFF
--- a/Categories/UIKit/UIViewController+AnyPromise.m
+++ b/Categories/UIKit/UIViewController+AnyPromise.m
@@ -15,7 +15,7 @@
 
 - (AnyPromise *)promiseViewController:(UIViewController *)vc animated:(BOOL)animated completion:(void (^)(void))block
 {
-    id vc2present = vc;
+    UIViewController *vc2present = vc;
     AnyPromise *promise = nil;
 
     if ([vc isKindOfClass:NSClassFromString(@"MFMailComposeViewController")]) {
@@ -72,8 +72,7 @@
     [self presentViewController:vc2present animated:animated completion:block];
 
     promise.finally(^{
-        //TODO can we be more specific?
-        [self dismissViewControllerAnimated:animated completion:nil];
+        [vc2present.presentingViewController dismissViewControllerAnimated:animated completion:nil];
     });
 
     return promise;


### PR DESCRIPTION
The proper way to dismiss a the viewController is to call
dismissViewControllerAnimated:completion on
vc2present.presentingViewController

Fixes #394 