### PR TITLE
Remove test targets to build together with framework targets

### DIFF
--- a/PromiseKit.xcodeproj/xcshareddata/xcschemes/PMKOSX.xcscheme
+++ b/PromiseKit.xcodeproj/xcshareddata/xcschemes/PMKOSX.xcscheme
@@ -28,36 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6388E1A11AD315F90074D85B"
-               BuildableName = "PMKTests.xctest"
-               BlueprintName = "PMKTests"
-               ReferencedContainer = "container:PromiseKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63533B321AE57A9300C10972"
-               BuildableName = "PMKAPlusTests.xctest"
-               BlueprintName = "PMKAPlusTests"
-               ReferencedContainer = "container:PromiseKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63CA14481AE9FBD000223904"
-               BuildableName = "PMKOSXCategoryTests.xctest"
-               BlueprintName = "PMKOSXCategoryTests"
-               ReferencedContainer = "container:PromiseKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/PromiseKit.xcodeproj/xcshareddata/xcschemes/PMKiOS.xcscheme
+++ b/PromiseKit.xcodeproj/xcshareddata/xcschemes/PMKiOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:PromiseKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63EBEAC41B6151AA0097FA42"
-               BuildableName = "PMKiOSUITests.xctest"
-               BlueprintName = "PMKiOSUITests"
-               ReferencedContainer = "container:PromiseKit.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -42,30 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "638E0ED41AEF16530052E28F"
-               BuildableName = "PMKiOSCategoryTests.xctest"
-               BlueprintName = "PMKiOSCategoryTests"
-               ReferencedContainer = "container:PromiseKit.xcodeproj">
-            </BuildableReference>
-            <LocationScenarioReference
-               identifier = "London, England"
-               referenceType = "1">
-            </LocationScenarioReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63EBEAC41B6151AA0097FA42"
-               BuildableName = "PMKiOSUITests.xctest"
-               BlueprintName = "PMKiOSUITests"
-               ReferencedContainer = "container:PromiseKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
Edited the build schemes for the iOS and OXS framework targets to not also build the test targets.  This gets rid of the following build warnings when build the frameworks via Carthage and Xcode 7.3:

Code Sign warning: CODE_SIGN_ENTITLEMENTS specified without specifying CODE_SIGN_IDENTITY. It is not possible to add entitlements to a binary without signing it.
warning: All interface orientations must be supported unless the app requires full screen.
warning: A launch storyboard or xib must be provided unless the app requires full screen.

The last two warnings  can easily also be fixed by setting the key `UIRequiresFullScreen` in the UI test target's `Info.plist`, however, for the code signing warnings, I could find no such easy fix other than just not build them together with the frameworks.  

I do not know what could break by not building the test targets together with the framework targets.  The discussion here mentions the approach I've taken: http://stackoverflow.com/questions/26109851/code-signing-is-required-for-product-type-unit-test-bundle-in-sdk-ios-8-0