### PR TITLE
Provide a way out in case Swift compiler really doesn't know which method or property is meant by "error"

### DIFF
--- a/Sources/Promise+Properties.swift
+++ b/Sources/Promise+Properties.swift
@@ -14,6 +14,14 @@ extension Promise {
     }
 
     /**
+     - Returns: The error with which this promise was rejected; `nil` if this promise is not rejected.
+       Alternative for the cases where the Swift compiler gets confused over the name of the `error` property
+    */
+    public var errorValue: ErrorType? {
+        return self.error
+    }
+
+    /**
      - Returns: `true` if the promise has not yet resolved.
     */
     public var pending: Bool {

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -391,6 +391,14 @@ public class Promise<T> {
     }
 
     /**
+     Provides an alias for the `error` function for cases where the Swift compiler gets into trouble inferring the right
+     types. If `error` does not work, consider using `onError` instead which does the same thing.
+    */
+    public func onError(policy policy: ErrorPolicy = .AllErrorsExceptCancellation, _ body: (ErrorType) -> Void) {
+        error(policy: policy, body)
+    }
+
+    /**
      The provided closure is executed when this promise is rejected giving you
      an opportunity to recover from the error and continue the promise chain.
     */

--- a/Tests/CorePromise/ErrorUnhandler.test.swift
+++ b/Tests/CorePromise/ErrorUnhandler.test.swift
@@ -116,6 +116,20 @@ class ErrorHandlingTests_Swift: XCTestCase {
         }
     }
 
+
+    // an alias called `onError` exists for the `error` function
+    func test7() {
+        twice { promise, ex in
+            PMKUnhandledErrorHandler = { err in
+                XCTFail()
+            }
+
+            promise.onError { error in
+                ex.fulfill()
+            }
+        }
+    }
+
     func testDoubleRejectDoesNotTriggerUnhandler() {
         enum Error: ErrorType {
             case Test


### PR DESCRIPTION
Fixes #347