### PR TITLE
Add xcuserdata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /Carthage
 /Cartfile.resolved
 /Build
+*.xcodeproj/xcuserdata/


### PR DESCRIPTION
When using PromiseKit as a subproject, Xcode keeps adding xcuserdata folders. If you're using git submodules it means that the submodule is perpetually considered out of sync while you're developing.