### PR TITLE
Make Image Picker test more reliable

### DIFF
--- a/Tests/UITests/TestUIImagePickerController.swift
+++ b/Tests/UITests/TestUIImagePickerController.swift
@@ -31,7 +31,7 @@ class UITest_UIImagePickerController_Swift: PMKiOSUITestCase {
         let tablesQuery = app.tables
         tablesQuery.staticTexts["3"].tap()
         tablesQuery.childrenMatchingType(.Cell).elementBoundByIndex(0).tap()
-        app.collectionViews.childrenMatchingType(.Cell).matchingIdentifier("Photo, Landscape, August 08, 2012, 4:55 PM").elementBoundByIndex(0).tap()
+        app.collectionViews.childrenMatchingType(.Cell).matchingPredicate(NSPredicate(format: "SELF.label BEGINSWITH %@", argumentArray: ["Photo, Landscape, August 08, 2012"])).elementBoundByIndex(0).tap()
 
         XCTAssertTrue(value)
     }
@@ -41,7 +41,7 @@ class UITest_UIImagePickerController_Swift: PMKiOSUITestCase {
         let tablesQuery = app.tables
         tablesQuery.staticTexts["4"].tap()
         tablesQuery.buttons["Moments"].tap()
-        app.collectionViews.childrenMatchingType(.Cell).matchingIdentifier("Photo, Landscape, August 08, 2012, 4:55 PM").elementBoundByIndex(0).tap()
+        app.collectionViews.childrenMatchingType(.Cell).matchingPredicate(NSPredicate(format: "SELF.label BEGINSWITH %@", argumentArray: ["Photo, Landscape, August 08, 2012"])).elementBoundByIndex(0).tap()
 
         XCTAssertTrue(value)
     }


### PR DESCRIPTION
Due to timezone differences, I think my simulator is showing different times for the photos so the test fails. I made it use a predicate to find the right photo.