### PR TITLE
Fix tvOS build settings for Carthage compatibility

### DIFF
--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -1869,11 +1869,14 @@
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_NO_COMMON_BLOCKS = YES;
+				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Sources/PMK.modulemap;
 				PRODUCT_NAME = PromiseKit;
 				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -1884,11 +1887,14 @@
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_NO_COMMON_BLOCKS = YES;
+				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = Sources/PMK.modulemap;
 				PRODUCT_NAME = PromiseKit;
 				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};


### PR DESCRIPTION
When integrating PromiseKit with a tvOS application via Carthage, I was getting `dyld: Library not loaded` dynamic linker errors when trying to launch the application. (It is possible that this issue does not affect CocoaPods integration.)

I verified that `PromiseKit.framework` was correctly embedded with the application bundle's `Frameworks` directory, and ran `lipo` on it to verify that I was integrating the correct platform.

After looking into the issue further, I noticed that the dynamic linker was looking in a different path than it was for all of the application's other embedded frameworks. I fixed the issue by changing some tvOS build settings for PromiseKit: `DYLIB_INSTALL_NAME_BASE` and `LD_DYLIB_INSTALL_NAME` now use the same settings as iOS, and `SKIP_INSTALL` has been turned on; framework installs only seem necessary on OS X.

Once I made these changes, I was able to get PromiseKit running on tvOS.