### PR TITLE
Removed OMGHTTPURLRQ dependency

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,0 @@
-github "mxcl/OMGHTTPURLRQ" ~> 3.1.2

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,4 @@
 github "AliSoftware/OHHTTPStubs"
 github "mxcl/Stubbilino"
 github "BoltsFramework/Bolts-iOS"
+github "mxcl/OMGHTTPURLRQ" ~> 3.1.2

--- a/Categories/Foundation/NSURLConnection+AnyPromise.m
+++ b/Categories/Foundation/NSURLConnection+AnyPromise.m
@@ -10,6 +10,7 @@
 #import <Foundation/NSURLResponse.h>
 #import "NSURLConnection+AnyPromise.h"
 #import <PromiseKit/PromiseKit.h>
+// When using Carthage add `github "mxcl/OMGHTTPURLRQ"` to your Cartfile.
 #import <OMGHTTPURLRQ/OMGHTTPURLRQ.h>
 #import <OMGHTTPURLRQ/OMGUserAgent.h>
 

--- a/Categories/Foundation/NSURLConnection+Promise.swift
+++ b/Categories/Foundation/NSURLConnection+Promise.swift
@@ -1,4 +1,5 @@
 import Foundation
+// When using Carthage add `github "mxcl/OMGHTTPURLRQ"` to your Cartfile.
 import OMGHTTPURLRQ
 #if !COCOAPODS
 import PromiseKit

--- a/Categories/Foundation/NSURLSession+Promise.swift
+++ b/Categories/Foundation/NSURLSession+Promise.swift
@@ -1,4 +1,5 @@
 import Foundation
+// When using Carthage add `github "mxcl/OMGHTTPURLRQ"` to your Cartfile.
 import OMGHTTPURLRQ
 #if !COCOAPODS
 import PromiseKit


### PR DESCRIPTION
Removes the OMGHTTPURLRQ carthage dependency since it is not used in the project build by carthage. If the user uses the relative category he/she should add the dependency to the cartfile manually. This also reduces carthage build time and avoids confusion.