### PR TITLE
Remove watchos exclusion of NSURLSession extension

### DIFF
--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -90,7 +90,7 @@ Pod::Spec.new do |s|
   s.subspec 'Foundation' do |ss|
     ss.ios.source_files = Dir['Categories/Foundation/*'] - Dir['Categories/Foundation/NSTask*']
     ss.osx.source_files = 'Categories/Foundation/*'
-    ss.watchos.source_files = Dir['Categories/Foundation/*'] - Dir['Categories/Foundation/NSTask*', 'Categories/Foundation/NSURL*']
+    ss.watchos.source_files = Dir['Categories/Foundation/*'] - Dir['Categories/Foundation/NSTask*', 'Categories/Foundation/NSURLConnection*']
     ss.dependency 'PromiseKit/CorePromise'
     ss.dependency 'OMGHTTPURLRQ', '~> 3.1.0'
     ss.frameworks = 'Foundation'


### PR DESCRIPTION
I've read in #265 that watchos support was added but that it wouldn't be necessary to have support for network requests. I'm not sure why that was concluded since it's perfectly possible to perform network requests from a watch app. The function used from the NSURLConnection Promise extension does not work but the one from the NSURLSession Promise extension works fine. I've tested it from a watch app.