### PR TITLE
Add WatchConnectivity category

### DIFF
--- a/Categories/WatchConnectivity/WCSession+Promise.swift
+++ b/Categories/WatchConnectivity/WCSession+Promise.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WatchConnectivity
+import PromiseKit
+
+@available(iOS 9.0, *)
+@available(iOSApplicationExtension 9.0, *)
+extension WCSession {
+
+    public func sendMessage(message: [String: AnyObject]) -> Promise<[String: AnyObject]> {
+        return Promise { resolver, error in
+            sendMessage(message, replyHandler: resolver, errorHandler: error)
+        }
+    }
+
+    public func sendMessageData(data: NSData) -> Promise<NSData> {
+        return Promise { resolver, error in
+            sendMessageData(data, replyHandler: resolver, errorHandler: error)
+        }
+    }
+}

--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -155,4 +155,12 @@ Pod::Spec.new do |s|
     ss.ios.frameworks = 'UIKit'
   end
 
+  s.subspec 'WatchConnectivity' do |ss|
+    ss.source_files = 'Categories/WatchConnectivity/*'
+    ss.dependency 'PromiseKit/CorePromise'
+    ss.frameworks = 'WatchConnectivity'
+    ss.ios.deployment_target = '8.0' # Watch Connectivity only works in iOS 9 but apps with a deployment target of 8.0 can still include it because of the availability check
+    ss.watchos.deployment_target = '2.0'
+  end
+
 end

--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		17470C5D1CBF8B17004FBBB8 /* PMKDefaultDispatchQueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17470C5C1CBF8B17004FBBB8 /* PMKDefaultDispatchQueueTest.swift */; };
 		17470C5F1CBF912E004FBBB8 /* PMKDefaultDispatchQueueTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17470C5E1CBF912E004FBBB8 /* PMKDefaultDispatchQueueTest.m */; };
 		2F0BAE0C1C901E9300A4DCA1 /* TestEventKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0BAE0B1C901E9300A4DCA1 /* TestEventKit.swift */; };
+		2F764A4D1CF6D53B00F6F7AD /* WCSession+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F764A4B1CF6D3BE00F6F7AD /* WCSession+Promise.swift */; };
+		2F764A501CF6D65000F6F7AD /* TestWatchConnectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F764A4E1CF6D61E00F6F7AD /* TestWatchConnectivity.swift */; };
 		2F814F131C73A8C800ABF4D1 /* EKEventStore+Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F814F111C73782100ABF4D1 /* EKEventStore+Promise.swift */; };
 		431B66E41CAC8022006CFC50 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6373805B1B3E1C8E0060B7CA /* Bolts.framework */; };
 		43EF78B41C5AB88600BCD8FB /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 63A60E1F1AFD795B00C4E692 /* after.m */; };
@@ -366,6 +368,8 @@
 		17470C5C1CBF8B17004FBBB8 /* PMKDefaultDispatchQueueTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PMKDefaultDispatchQueueTest.swift; path = CorePromise/PMKDefaultDispatchQueueTest.swift; sourceTree = "<group>"; };
 		17470C5E1CBF912E004FBBB8 /* PMKDefaultDispatchQueueTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PMKDefaultDispatchQueueTest.m; path = CorePromise/PMKDefaultDispatchQueueTest.m; sourceTree = "<group>"; };
 		2F0BAE0B1C901E9300A4DCA1 /* TestEventKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEventKit.swift; sourceTree = "<group>"; };
+		2F764A4B1CF6D3BE00F6F7AD /* WCSession+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WCSession+Promise.swift"; sourceTree = "<group>"; };
+		2F764A4E1CF6D61E00F6F7AD /* TestWatchConnectivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestWatchConnectivity.swift; path = Categories/TestWatchConnectivity.swift; sourceTree = "<group>"; };
 		2F814F111C73782100ABF4D1 /* EKEventStore+Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "EKEventStore+Promise.swift"; sourceTree = "<group>"; };
 		43EF78A61C5AA12B00BCD8FB /* PromiseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6302AC8E1AEF42F2001F0069 /* ACAccountStore+AnyPromise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ACAccountStore+AnyPromise.h"; sourceTree = "<group>"; };
@@ -616,6 +620,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2F764A4A1CF6D34E00F6F7AD /* WatchConnectivity */ = {
+			isa = PBXGroup;
+			children = (
+				2F764A4B1CF6D3BE00F6F7AD /* WCSession+Promise.swift */,
+			);
+			path = WatchConnectivity;
+			sourceTree = "<group>";
+		};
 		2F814F101C73779800ABF4D1 /* EventKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -949,6 +961,7 @@
 				6302ACC61AEF42F2001F0069 /* StoreKit */,
 				6302ACCA1AEF42F2001F0069 /* SystemConfiguration */,
 				6302ACCD1AEF42F2001F0069 /* UIKit */,
+				2F764A4A1CF6D34E00F6F7AD /* WatchConnectivity */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -1043,6 +1056,7 @@
 				2F0BAE0B1C901E9300A4DCA1 /* TestEventKit.swift */,
 				63DF17031AEAC46E00BE97DD /* TestMessageUI.m */,
 				638AF9661B62B7DE0045C3E8 /* TestMessageUI.swift */,
+				2F764A4E1CF6D61E00F6F7AD /* TestWatchConnectivity.swift */,
 				6391FD2C1B62ED7D00671798 /* TestFoundation */,
 				63DF16FF1AEAC46E00BE97DD /* TestMapKit.swift */,
 				63DF17001AEAC46E00BE97DD /* TestQuartzCore.m */,
@@ -1584,6 +1598,7 @@
 				638AF8CF1B62B1AF0045C3E8 /* afterlife.swift in Sources */,
 				6391FD251B62E0FF00671798 /* TestUIImagePickerController.swift in Sources */,
 				638AF8D21B62B1AF0045C3E8 /* NSNotificationCenter+AnyPromise.m in Sources */,
+				2F764A4D1CF6D53B00F6F7AD /* WCSession+Promise.swift in Sources */,
 				638AF8D31B62B1AF0045C3E8 /* NSNotificationCenter+Promise.swift in Sources */,
 				638AF8D81B62B1AF0045C3E8 /* NSURLConnection+AnyPromise.m in Sources */,
 				638AF8D91B62B1AF0045C3E8 /* NSURLConnection+Promise.swift in Sources */,
@@ -1625,6 +1640,7 @@
 				638AF9531B62B7230045C3E8 /* TestNSURLConnection.swift in Sources */,
 				638AF9671B62B7DE0045C3E8 /* TestMessageUI.swift in Sources */,
 				638AF9541B62B7230045C3E8 /* TestNSNotificationCenter.swift in Sources */,
+				2F764A501CF6D65000F6F7AD /* TestWatchConnectivity.swift in Sources */,
 				638AF9551B62B7230045C3E8 /* TestNSObject.swift in Sources */,
 				638AF9561B62B7230045C3E8 /* TestMapKit.swift in Sources */,
 				638AF9571B62B7230045C3E8 /* TestQuartzCore.m in Sources */,

--- a/Tests/Categories/TestWatchConnectivity.swift
+++ b/Tests/Categories/TestWatchConnectivity.swift
@@ -1,0 +1,56 @@
+import WatchConnectivity
+import Foundation
+import PromiseKit
+import XCTest
+
+import Foundation
+
+@available(iOS 9.0, *)
+@available(iOSApplicationExtension 9.0, *)
+class Test_WatchConnectivity_Swift: XCTestCase {
+    class MockSession: WCSession {
+
+        var fail = false
+
+        override func sendMessage(message: [String : AnyObject], replyHandler: (([String : AnyObject]) -> Void)?, errorHandler: ((NSError) -> Void)?) {
+            if fail {
+                errorHandler?(NSError(domain: "Test", code: 1, userInfo: [:]))
+            } else {
+                replyHandler?(["response": "Success"])
+            }
+        }
+    }
+
+    func testSuccess() {
+
+        let ex = expectationWithDescription("Success callback")
+        let session = MockSession.defaultSession() as! MockSession
+        session.fail = false
+        session.sendMessage(["message": "test"]).then { response -> () in
+            XCTAssertEqual(response as! [String: String], ["response": "Success"])
+            ex.fulfill()
+        }.error { _ in
+            XCTFail("Should not fail")
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+
+    func testFailure() {
+        class MockFailSession: WCSession {
+            private override func sendMessage(message: [String : AnyObject], replyHandler: (([String : AnyObject]) -> Void)?, errorHandler: ((NSError) -> Void)?) {
+                errorHandler?(NSError(domain: "Test", code: 1, userInfo: [:]))
+            }
+        }
+
+        let ex = expectationWithDescription("Error callback")
+        let session = MockSession.defaultSession() as! MockSession
+        session.fail = true
+        session.sendMessage(["message": "test"]).then { response -> () in
+            XCTFail("Should not succeed")
+        }.error { error in
+            XCTAssertEqual((error as NSError).domain, "Test")
+            ex.fulfill()
+        }
+        waitForExpectationsWithTimeout(1, handler: nil)
+    }
+}


### PR DESCRIPTION
This pull request adds support for the WatchConnectivity framework that's used to communicate between the iPhone and Apple Watch apps.

Two extension functions returning promises have been added to `WCSession` for the `sendMessage` and `sendMessageData` functions.