### PR TITLE
join for void promises

### DIFF
--- a/Sources/join.swift
+++ b/Sources/join.swift
@@ -20,6 +20,10 @@ public func join<T>(promises: Promise<T>...) -> Promise<[T]> {
     return join(promises)
 }
 
+public func join(promises: [Promise<Void>]) -> Promise<Void> {
+    return join(promises).then { (result:[Void]) in return Promise() }
+}
+
 public func join<T>(promises: [Promise<T>]) -> Promise<[T]> {
     guard !promises.isEmpty else { return Promise<[T]>([]) }
   


### PR DESCRIPTION
Without this fix I get a compilation error

No 'join' candidates produce the expected contextual result type
'Promise<Void>' (aka 'Promise<()>')

when joining void promises.