### PR TITLE
Minor document updates.

### DIFF
--- a/_posts/2014-12-31-getting-started.md
+++ b/_posts/2014-12-31-getting-started.md
@@ -22,20 +22,22 @@ You will be prompted for your password.
 First we must first ensure that our Terminal is open at the correct directory. Ensure that your Xcode project is open, and that it is the *only* open Xcode project. Then type this into Terminal and press `enter`:
 
 {% highlight bash %}
-D="$(osascript -e "tell application \"Xcode\" to get path of project 1")/.."; cd $D
+D="$(osascript -e "tell application \"Xcode\" to get path of project 1")/.."; cd "$D"
 {% endhighlight %}
 
 Every project that uses CocoaPods must have a `Podfile`: a text file at your project’s root folder that describes the libraries we want to import. Let’s create it:
 
 {% highlight bash %}
-touch Podfile && open -e Podfile
+pod init && open -e Podfile
 {% endhighlight %}
 
-TextEdit will open, in the empty window type:
+TextEdit will open. Add PromiseKit to the default target. It should look something like this. 
 
 {% highlight ruby %}
-source 'https://github.com/CocoaPods/Specs.git'
-pod 'PromiseKit'
+target 'your-project-name' do
+    use_frameworks!
+    pod "PromiseKit"
+end
 {% endhighlight %}
 
 Save the file.

--- a/_posts/2015-01-24-sealing-your-own-promises.md
+++ b/_posts/2015-01-24-sealing-your-own-promises.md
@@ -30,8 +30,8 @@ This unusual syntax (for Objective-C) encourages encapsulation. `resolve` is pri
 Often you may need to do some work in a background queue as part of your new promise; if so, don’t be afraid to start using `thenOn` or `thenInBackground`. `then` and `thenOn`, return new promises, so you can just return that promise instead of the initial promise, and your API is A-OK.
 
 {% highlight objectivec %}
-- (PMKPromise *)kittens {
-    return [PMKPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+- (AnyPromise *)kittens {
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         [KittenPower fetch:^(NSArray kittens){
             resolve(kittens);
         }];


### PR DESCRIPTION
 - Updated getting-started for Cocoapods 1.0
 - Updated sealing your own promises with AnyPromise naming.
 - Made the project path script accept spaces.

For #456 