### PR TITLE
Fix compile error in when.m

### DIFF
--- a/Sources/when.m
+++ b/Sources/when.m
@@ -34,6 +34,7 @@ AnyPromise *PMKWhen(id promises) {
     struct PMKProgress {
         int completedUnitCount;
         int totalUnitCount;
+        double fractionCompleted;
     };
     __block struct PMKProgress progress;
 #endif


### PR DESCRIPTION
The `PMKProgress` struct was missing a `fractionCompleted` member which resulted in a compile error if `PMKDisableProgress` was defined.