### PR TITLE
Add PMKDefaultDispatchQueue and PMKUnhandledExceptionHandler to CorePromise subspec

### DIFF
--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -63,7 +63,7 @@ Pod::Spec.new do |s|
   s.subspec 'CorePromise' do |ss|
     hh = Dir['Sources/*.h'] - Dir['Sources/*+Private.h']
     
-    ss.source_files = 'Sources/*.{swift}', 'Sources/{after,AnyPromise,dispatch_promise,hang,join,PMKPromise,when}.m', *hh
+    ss.source_files = 'Sources/*.{swift}', 'Sources/{after,AnyPromise,dispatch_promise,hang,join,PMKPromise,when,PMKDefaultDispatchQueue,PMKUnhandledExceptionHandler}.m', *hh
     ss.public_header_files = hh
     ss.preserve_paths = 'Sources/AnyPromise+Private.h', 'Sources/PMKCallVariadicBlock.m', 'Sources/NSMethodSignatureForBlock.m'
     ss.frameworks = 'Foundation'


### PR DESCRIPTION
@mxcl 

Fixes https://github.com/mxcl/PromiseKit/issues/467

`PMKDefaultDispatchQueue.m` and `PMKUnhandledExceptionHandler.m` were not being added by cocoapods in the CorePromise subspec, causing two undefined symbol errors.

I did not test the current master version in my app but looking at https://github.com/mxcl/PromiseKit/blob/master/PromiseKit.podspec#L70 it seems that the linking error would also happen in `master`. Let me know if you want another PR for that.