### PR TITLE
make AnimationOptions members public

### DIFF
--- a/Categories/UIKit/UIViewController+Promise.swift
+++ b/Categories/UIKit/UIViewController+Promise.swift
@@ -40,9 +40,9 @@ extension UIViewController {
         }
         public let rawValue: Int
 
-        static let None      = AnimationOptions(rawValue: 0)
-        static let Appear    = AnimationOptions(rawValue: 1 << 0)
-        static let Disappear = AnimationOptions(rawValue: 1 << 1)
+        public static let None      = AnimationOptions(rawValue: 0)
+        public static let Appear    = AnimationOptions(rawValue: 1 << 0)
+        public static let Disappear = AnimationOptions(rawValue: 1 << 1)
     }
 
     @available(*, deprecated=3.4, renamed="promiseViewController(_:animate:fulfills:completion:)")


### PR DESCRIPTION
## What is this?
This change opens up the `AnimationOptions` members `None`, `Appear` and `Disappear` as public.

## Why?
`promiseViewController(_:animate:fulfills:completion:)` asks for `AnimationOptions` as a parameter, however none of its members are marked `public` so users of the framework can't actually get to them. The only alternative is by calling the public initialiser `init(rawValue:)`, which is rather fragile.