### PR TITLE
Let `animated` and `completion` do something

### DIFF
--- a/Categories/UIKit/PMKAlertController.swift
+++ b/Categories/UIKit/PMKAlertController.swift
@@ -71,7 +71,7 @@ public class PMKAlertController {
 extension UIViewController {
     public func promiseViewController(vc: PMKAlertController, animated: Bool = true, completion: (() -> Void)? = nil) -> Promise<UIAlertAction> {
         vc.retainCycle = vc
-        presentViewController(vc.UIAlertController, animated: true, completion: nil)
+        presentViewController(vc.UIAlertController, animated: animated, completion: completion)
         vc.promise.always { _ -> Void in
             vc.retainCycle = nil
         }


### PR DESCRIPTION
Not sure why you're hard-coding values where the default parameters are more than sufficient. Why not let the caller decide whether he wants presentViewController() to animate, and/or do something when it's finished? Is this intentional? If so, the parameters should be removed entirely from the function definition, to prevent confusion.