### PR TITLE
Fix podspec

### DIFF
--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -111,7 +111,7 @@ Pod::Spec.new do |s|
   s.subspec 'OMGHTTPURLRQ' do |ss|
     ss.source_files = 'Extensions/OMGHTTPURLRQ/Sources/*'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.dependency 'OMGHTTPURLRQ' ~> 3.2
+    ss.dependency 'OMGHTTPURLRQ', '~> 3.2'
     ss.frameworks = 'Foundation'
   end
   


### PR DESCRIPTION
There was an error in the Podspec, resulting in the following error when installing:

[!] Unable to find a specification for 'PromiseKit'.

[!] Unable to load a podspec from `PromiseKit.podspec`, skipping:

Pod::DSLError