### PR TITLE
Make Promise public instead of open

### DIFF
--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -17,7 +17,7 @@ import func Foundation.NSLog
 
  - SeeAlso: [PromiseKit `then` Guide](http://promisekit.org/docs/)
  */
-open class Promise<T> {
+public class Promise<T> {
     let state: State<T>
 
     /**


### PR DESCRIPTION
Not sure if this is intentional. Does it make sense to subclass `Promise`? Are people doing this?