### PR TITLE
Move contain_zalgo to DispatchQueue

### DIFF
--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -35,8 +35,8 @@ open class Promise<T> {
          }
 
      - Parameter resolvers: The provided closure is called immediately on the active thread; commence your asynchronous task, calling either fulfill or reject when it completes.
-      - Parameter fulfill: Fulfills this promise with the provided value.
-      - Parameter reject: Rejects this promise with the provided error.
+     - Parameter fulfill: Fulfills this promise with the provided value.
+     - Parameter reject: Rejects this promise with the provided error.
 
      - Returns: A new promise.
 

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -39,7 +39,7 @@ class State<T> {
         pipe { resolution in
             switch resolution {
             case .fulfilled(let value):
-                contain_zalgo(q, rejecter: rejecter) {
+                q.containZalgo(rejecter: rejecter) {
                     try body(value)
                 }
             case .rejected(let error, let token):
@@ -50,7 +50,7 @@ class State<T> {
 
     final func always(on q: DispatchQueue, body: @escaping (Resolution<T>) -> Void) {
         pipe { resolution in
-            contain_zalgo(q) {
+            q.containZalgo {
                 body(resolution)
             }
         }
@@ -64,7 +64,7 @@ class State<T> {
             case (.rejected(let error, _), .allErrorsExceptCancellation) where error.isCancelledError:
                 resolve(resolution)
             case (let .rejected(error, token), _):
-                contain_zalgo(q, rejecter: resolve) {
+                q.containZalgo(rejecter: resolve) {
                     token.consumed = true
                     try body(error)
                 }

--- a/Sources/Zalgo.swift
+++ b/Sources/Zalgo.swift
@@ -64,17 +64,18 @@ public let zalgo = DispatchQueue(label: "Zalgo")
  */
 public let waldo = DispatchQueue(label: "Waldo")
 
-
-@inline(__always) func contain_zalgo(_ q: DispatchQueue, body: @escaping () -> Void) {
-    if q === zalgo || q === waldo && !Thread.isMainThread {
-        body()
-    } else {
-        q.async(execute: body)
+extension DispatchQueue {
+    @inline(__always) func containZalgo(body: @escaping () -> Void) {
+        if self === zalgo || (self === waldo && !Thread.isMainThread) {
+            body()
+        } else {
+            async(execute: body)
+        }
     }
-}
 
-@inline(__always) func contain_zalgo<T>(_ q: DispatchQueue, rejecter reject: @escaping (Resolution<T>) -> Void, block: @escaping () throws -> Void) {
-    contain_zalgo(q) {
-        do { try block() } catch { reject(Resolution(error)) }
+    @inline(__always) func containZalgo<T>(rejecter reject: @escaping (Resolution<T>) -> Void, block: @escaping () throws -> Void) {
+        containZalgo() {
+            do { try block() } catch { reject(Resolution(error)) }
+        }
     }
 }


### PR DESCRIPTION
I also wonder if something like `asyncIfNotZalgo` is a better name than `containZalgo`, since it wasn't obvious to me at first than `containZalgo` dispatched.