### PR TITLE
#560 Promises tuple

### DIFF
--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		49A5583D1DC33BD000E4D01B /* 03_JointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A5583B1DC33BC800E4D01B /* 03_JointTests.swift */; };
 		49A5584D1DC5185900E4D01B /* 03_WrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A5584B1DC5172F00E4D01B /* 03_WrapTests.swift */; };
+		5CEBAEDBCFC8EEA3C9059EAC /* 05_PromiseTupleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CEBA3A1969A7992F3379177 /* 05_PromiseTupleTests.swift */; };
 		6314112B1D5978D700E24B9E /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B0AC571D595E1B00FA21D9 /* PromiseKit.framework */; };
 		631411311D5978EB00E24B9E /* PMKDefaultDispatchQueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635D641B1D59635300BC0AF5 /* PMKDefaultDispatchQueueTest.swift */; };
 		631411381D59795700E24B9E /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B0AC571D595E1B00FA21D9 /* PromiseKit.framework */; };
@@ -108,6 +109,7 @@
 /* Begin PBXFileReference section */
 		49A5583B1DC33BC800E4D01B /* 03_JointTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = 03_JointTests.swift; path = Tests/CorePromise/03_JointTests.swift; sourceTree = "<group>"; };
 		49A5584B1DC5172F00E4D01B /* 03_WrapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = 03_WrapTests.swift; path = Tests/CorePromise/03_WrapTests.swift; sourceTree = "<group>"; };
+		5CEBA3A1969A7992F3379177 /* 05_PromiseTupleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = 05_PromiseTupleTests.swift; path = Tests/CorePromise/05_PromiseTupleTests.swift; sourceTree = "<group>"; };
 		630019221D596292003B4E30 /* PMKCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6314112F1D5978D700E24B9E /* PMKDispatchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKDispatchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6314113C1D59795700E24B9E /* PMKBridgeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKBridgeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -269,6 +271,7 @@
 				635D64181D59635300BC0AF5 /* Infrastructure.h */,
 				635D64191D59635300BC0AF5 /* Infrastructure.m */,
 				635D641A1D59635300BC0AF5 /* Infrastructure.swift */,
+				5CEBA3A1969A7992F3379177 /* 05_PromiseTupleTests.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -564,6 +567,7 @@
 				635D642C1D59635300BC0AF5 /* 99_RegressionTests.swift in Sources */,
 				635D641C1D59635300BC0AF5 /* 01_AnyPromiseTests.m in Sources */,
 				635D642E1D59635300BC0AF5 /* Infrastructure.swift in Sources */,
+				5CEBAEDBCFC8EEA3C9059EAC /* 05_PromiseTupleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -185,7 +185,7 @@ open class Promise<T> {
      This variant of `then` allows returning a tuple of promises within provided closure. All of the returned
      promises needs be fulfilled for this promise to be marked as resolved.
 
-     - Note: At maximum 3 promises may be returned in a tuple
+     - Note: At maximum 5 promises may be returned in a tuple
      - Note: If *any* of the tuple-provided promises reject, the returned promise is immediately rejected with that error.
      - Warning: In the event of rejection the other promises will continue to resolve and, as per any other promise, will either fulfill or reject.
      - Parameter on: The queue to which the provided closure dispatches.

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -180,6 +180,68 @@ open class Promise<T> {
     }
 
     /**
+     The provided closure executes when this promise resolves.
+
+     This variant of `then` allows returning a tuple of promises within provided closure. All of the returned
+     promises needs be fulfilled for this promise to be marked as resolved.
+
+     - Note: At maximum 3 promises may be returned in a tuple
+     - Note: If *any* of the tuple-provided promises reject, the returned promise is immediately rejected with that error.
+     - Warning: In the event of rejection the other promises will continue to resolve and, as per any other promise, will either fulfill or reject.
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter execute: The closure that executes when this promise fulfills.
+     - Returns: A new promise that resolves when all promises returned from the provided closure resolve. For example:
+
+           loginPromise.then { _ -> (Promise<Data>, Promise<UIImage>)
+               return (URLSession.GET(userUrl), URLSession.dataTask(with: avatarUrl).asImage())
+           }.then { userData, avatarImage in
+               //…
+           }
+     */
+    public func then<U, V>(on q: DispatchQueue = .default, execute body: @escaping (T) throws -> (Promise<U>, Promise<V>)) -> Promise<(U, V)> {
+        var rv: Promise<(U, V)>!
+        rv = Promise<(U, V)> { resolve in
+            state.then(on: q, else: resolve) { value in
+                let (promiseU, promiseV) = try body(value)
+                guard promiseU !== rv && promiseV !== rv else { throw PMKError.returnedSelf }
+                when(fulfilled: promiseU, promiseV).state.pipe(resolve)
+            }
+        }
+        return rv
+    }
+
+    /**
+     The provided closure executes when this promise resolves.
+
+     This variant of `then` allows returning a tuple of promises within provided closure. All of the returned
+     promises needs be fulfilled for this promise to be marked as resolved.
+
+     - Note: At maximum 3 promises may be returned in a tuple
+     - Note: If *any* of the tuple-provided promises reject, the returned promise is immediately rejected with that error.
+     - Warning: In the event of rejection the other promises will continue to resolve and, as per any other promise, will either fulfill or reject.
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter execute: The closure that executes when this promise fulfills.
+     - Returns: A new promise that resolves when all promises returned from the provided closure resolve. For example:
+
+           loginPromise.then { _ -> (Promise<Data>, Promise<Data>, Promise<UIImage>)
+               return (URLSession.GET(userUrl), URLSession.GET(sessionUrl), URLSession.dataTask(with: avatarUrl).asImage())
+           }.then { userData, sessionData, avatarImage in
+               //…
+           }
+     */
+    public func then<U, V, X>(on q: DispatchQueue = .default, execute body: @escaping (T) throws -> (Promise<U>, Promise<V>, Promise<X>)) -> Promise<(U, V, X)> {
+        var rv: Promise<(U, V, X)>!
+        rv = Promise<(U, V, X)> { resolve in
+            state.then(on: q, else: resolve) { value in
+                let (promiseU, promiseV, promiseX) = try body(value)
+                guard promiseU !== rv && promiseV !== rv && promiseX !== rv else { throw PMKError.returnedSelf }
+                when(fulfilled: promiseU, promiseV, promiseX).state.pipe(resolve)
+            }
+        }
+        return rv
+    }
+
+    /**
      The provided closure executes when this promise rejects.
 
      Rejecting a promise cascades: rejecting all subsequent promises (unless

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -222,7 +222,9 @@ open class Promise<T> {
         return Promise<U> { resolve in
             state.then(on: q, else: resolve) { value in
                 let promise = try body(value)
-                when(promise).state.pipe(resolve)
+
+                // since when(promise) switches to `zalgo`, we have to pipe back to `q`
+                when(promise).state.pipe(on: q, to: resolve)
             }
         }
     }

--- a/Sources/State.swift
+++ b/Sources/State.swift
@@ -35,6 +35,14 @@ class State<T> {
         }
     }
 
+    final func pipe(on q: DispatchQueue, to body: @escaping (Resolution<T>) -> Void) {
+        pipe { resolution in
+            contain_zalgo(q) {
+                body(resolution)
+            }
+        }
+    }
+
     final func then<U>(on q: DispatchQueue, else rejecter: @escaping (Resolution<U>) -> Void, execute body: @escaping (T) throws -> Void) {
         pipe { resolution in
             switch resolution {

--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -86,8 +86,18 @@ public func when<U, V>(fulfilled pu: Promise<U>, _ pv: Promise<V>) -> Promise<(U
 }
 
 /// Wait for all promises in a set to fulfill.
-public func when<U, V, X>(fulfilled pu: Promise<U>, _ pv: Promise<V>, _ px: Promise<X>) -> Promise<(U, V, X)> {
-    return _when([pu.asVoid(), pv.asVoid(), px.asVoid()]).then(on: zalgo) { (pu.value!, pv.value!, px.value!) }
+public func when<U, V, W>(fulfilled pu: Promise<U>, _ pv: Promise<V>, _ pw: Promise<W>) -> Promise<(U, V, W)> {
+    return _when([pu.asVoid(), pv.asVoid(), pw.asVoid()]).then(on: zalgo) { (pu.value!, pv.value!, pw.value!) }
+}
+
+/// Wait for all promises in a set to fulfill.
+public func when<U, V, W, X>(fulfilled pu: Promise<U>, _ pv: Promise<V>, _ pw: Promise<W>, _ px: Promise<X>) -> Promise<(U, V, W, X)> {
+    return _when([pu.asVoid(), pv.asVoid(), pw.asVoid(), px.asVoid()]).then(on: zalgo) { (pu.value!, pv.value!, pw.value!, px.value!) }
+}
+
+/// Wait for all promises in a set to fulfill.
+public func when<U, V, W, X, Y>(fulfilled pu: Promise<U>, _ pv: Promise<V>, _ pw: Promise<W>, _ px: Promise<X>, _ py: Promise<Y>) -> Promise<(U, V, W, X, Y)> {
+    return _when([pu.asVoid(), pv.asVoid(), pw.asVoid(), px.asVoid(), py.asVoid()]).then(on: zalgo) { (pu.value!, pv.value!, pw.value!, px.value!, py.value!) }
 }
 
 /**

--- a/Tests/CorePromise/03_WhenTests.swift
+++ b/Tests/CorePromise/03_WhenTests.swift
@@ -30,13 +30,61 @@ class WhenTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testTuple() {
+    func testDoubleTuple() {
         let e1 = expectation(description: "")
         let p1 = Promise(value: 1)
         let p2 = Promise(value: "abc")
-        when(fulfilled: p1, p2).then{ (x: Int, y: String) -> Void in
+        when(fulfilled: p1, p2).then{ x, y -> Void in
             XCTAssertEqual(x, 1)
             XCTAssertEqual(y, "abc")
+            e1.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testTripleTuple() {
+        let e1 = expectation(description: "")
+        let p1 = Promise(value: 1)
+        let p2 = Promise(value: "abc")
+        let p3 = Promise(value: 1.0)
+        when(fulfilled: p1, p2, p3).then { u, v, w -> Void in
+            XCTAssertEqual(1, u)
+            XCTAssertEqual("abc", v)
+            XCTAssertEqual(1.0, w)
+            e1.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testQuadrupleTuple() {
+        let e1 = expectation(description: "")
+        let p1 = Promise(value: 1)
+        let p2 = Promise(value: "abc")
+        let p3 = Promise(value: 1.0)
+        let p4 = Promise(value: true)
+        when(fulfilled: p1, p2, p3, p4).then { u, v, w, x -> Void in
+            XCTAssertEqual(1, u)
+            XCTAssertEqual("abc", v)
+            XCTAssertEqual(1.0, w)
+            XCTAssertEqual(true, x)
+            e1.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testQuintupleTuple() {
+        let e1 = expectation(description: "")
+        let p1 = Promise(value: 1)
+        let p2 = Promise(value: "abc")
+        let p3 = Promise(value: 1.0)
+        let p4 = Promise(value: true)
+        let p5 = Promise(value: "a" as Character)
+        when(fulfilled: p1, p2, p3, p4, p5).then { u, v, w, x, y -> Void in
+            XCTAssertEqual(1, u)
+            XCTAssertEqual("abc", v)
+            XCTAssertEqual(1.0, w)
+            XCTAssertEqual(true, x)
+            XCTAssertEqual("a" as Character, y)
             e1.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)

--- a/Tests/CorePromise/05_PromiseTupleTests.swift
+++ b/Tests/CorePromise/05_PromiseTupleTests.swift
@@ -1,0 +1,43 @@
+import PromiseKit
+import XCTest
+
+class PromiseTupleTests: XCTestCase {
+
+    func testTupleWithThreeMixedTypePromises() {
+        let ex = expectation(description: "promise tuple values returned")
+
+        _ = firstly {
+            Promise(value: ())
+        }.then { () -> (Promise<Int>, Promise<Bool>, Promise<String>) in
+            let integer = Promise(value: 1)
+            let boolean = Promise(value: true)
+            let string = Promise(value: "yes")
+            return (integer, boolean, string)
+        }.then { integer, boolean, string -> Void in
+            XCTAssertEqual(1, integer)
+            XCTAssertEqual(true, boolean)
+            XCTAssertEqual("yes", string)
+            ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testTupleWithTwoMixedTypePromises() {
+        let ex = expectation(description: "promise tuple values returned")
+
+        _ = firstly {
+            Promise(value: ())
+        }.then { () -> (Promise<Int>, Promise<String>) in
+            let integer = after(interval: 0.1).then { 1 }
+            let string = Promise(value: "success")
+            return (integer, string)
+        }.then { (integer, string) -> Void in
+            XCTAssertEqual(1, integer)
+            XCTAssertEqual("success", string)
+            ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/Tests/CorePromise/05_PromiseTupleTests.swift
+++ b/Tests/CorePromise/05_PromiseTupleTests.swift
@@ -3,7 +3,30 @@ import XCTest
 
 class PromiseTupleTests: XCTestCase {
 
-    func testTupleWithThreeMixedTypePromises() {
+
+    enum TestError: Error {
+        case sthWrong
+    }
+
+    func testDoublePromisesTuple() {
+        let ex = expectation(description: "promise tuple values returned")
+
+        _ = firstly {
+            Promise(value: ())
+        }.then { () -> (Promise<Int>, Promise<String>) in
+            let integer = after(interval: 0.1).then { 1 }
+            let string = Promise(value: "success")
+            return (integer, string)
+        }.then { (integer, string) -> Void in
+            XCTAssertEqual(1, integer)
+            XCTAssertEqual("success", string)
+            ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testTriplePromisesTuple() {
         let ex = expectation(description: "promise tuple values returned")
 
         _ = firstly {
@@ -23,21 +46,95 @@ class PromiseTupleTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testTupleWithTwoMixedTypePromises() {
+    func testQuadruplePromisesTuple() {
         let ex = expectation(description: "promise tuple values returned")
 
         _ = firstly {
             Promise(value: ())
-        }.then { () -> (Promise<Int>, Promise<String>) in
-            let integer = after(interval: 0.1).then { 1 }
+        }.then { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>) in
+            let boolean = after(interval: 0.1).then { true }
+            let integer = Promise(value: 1)
             let string = Promise(value: "success")
-            return (integer, string)
-        }.then { (integer, string) -> Void in
+            let integerTuple = after(interval: 0.1).then { (2, 3) }
+            return (boolean, integer, string, integerTuple)
+        }.then { (boolean, integer, string, integerTuple) -> Void in
+            XCTAssertEqual(true, boolean)
             XCTAssertEqual(1, integer)
             XCTAssertEqual("success", string)
+            XCTAssertEqual(2, integerTuple.0)
+            XCTAssertEqual(3, integerTuple.1)
             ex.fulfill()
         }
 
         waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testQuintuplePromisesTuple() {
+        let ex = expectation(description: "promise tuple values returned")
+
+        _ = firstly {
+            Promise(value: ())
+        }.then { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>, Promise<Double>) in
+            let boolean = after(interval: 0.1).then { true }
+            let integer = Promise(value: 1)
+            let string = Promise(value: "success")
+            let integerTuple = after(interval: 0.1).then { (2, 3) }
+            let double = Promise(value: 0.1)
+            return (boolean, integer, string, integerTuple, double)
+        }.then { (boolean, integer, string, integerTuple, double) -> Void in
+            XCTAssertEqual(true, boolean)
+            XCTAssertEqual(1, integer)
+            XCTAssertEqual("success", string)
+            XCTAssertEqual(2, integerTuple.0)
+            XCTAssertEqual(3, integerTuple.1)
+            XCTAssertEqual(0.1, double)
+            ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+
+    func testNtuplePromisesFail(generator: (Promise<Void>, Promise<Any>, Promise<Any>) -> Promise<Void>) {
+        let ex = expectation(description: "")
+
+        generator(after(interval: 0.1), Promise<Any>(value: 1), Promise<Any>(error: TestError.sthWrong)).then {
+            XCTFail("Then called instead of `catch`")
+        }.catch { e in
+            if case TestError.sthWrong = e {
+                ex.fulfill()
+            } else {
+                XCTFail("Wrong error received")
+            }
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testDoublePromisesTupleFail() {
+        testNtuplePromisesFail { after, success, err in
+            after.then { (err, success) }
+                 .then { (_: Any, _: Any) in () } // hint to compiler, that tuple version of `then` shall be used
+        }
+    }
+
+    func testTriplePromisesTupleFail() {
+        testNtuplePromisesFail { after, success, err in
+            after.then { (success, err, success) }
+                 .then { (_: Any, _: Any, _: Any) in () }
+        }
+    }
+
+    func testQuadruplePromisesTupleFail() {
+        testNtuplePromisesFail { after, success, err in
+            after.then { (err, err, err, success) }
+                 .then { (_: Any, _: Any, _: Any, _: Any) in () }
+        }
+    }
+
+    func testQuintuplePromisesTupleFail() {
+        testNtuplePromisesFail { after, success, err in
+            after.then { (success, success, err, err, success) }
+                 .then { (_: Any, _: Any, _: Any, _: Any, _: Any) in () }
+        }
     }
 }

--- a/Tests/CorePromise/05_PromiseTupleTests.swift
+++ b/Tests/CorePromise/05_PromiseTupleTests.swift
@@ -3,99 +3,82 @@ import XCTest
 
 class PromiseTupleTests: XCTestCase {
 
+    /// test then tuples
 
-    enum TestError: Error {
-        case sthWrong
-    }
-
-    func testDoublePromisesTuple() {
+    func testThenReturningDoublePromisesTuple() {
         let ex = expectation(description: "promise tuple values returned")
-
-        _ = firstly {
-            Promise(value: ())
-        }.then { () -> (Promise<Int>, Promise<String>) in
-            let integer = after(interval: 0.1).then { 1 }
-            let string = Promise(value: "success")
-            return (integer, string)
-        }.then { (integer, string) -> Void in
-            XCTAssertEqual(1, integer)
-            XCTAssertEqual("success", string)
-            ex.fulfill()
+        getPromises { a, b, _, _, _, first in
+            first.then { () -> (Promise<Bool>, Promise<Int>) in
+                return (a, b)
+            }.then { (bool, integer) -> Void in
+                XCTAssertEqual(a.value, bool)
+                XCTAssertEqual(b.value, integer)
+                ex.fulfill()
+            }
         }
 
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testTriplePromisesTuple() {
+    func testThenReturningTriplePromisesTuple() {
         let ex = expectation(description: "promise tuple values returned")
 
-        _ = firstly {
-            Promise(value: ())
-        }.then { () -> (Promise<Int>, Promise<Bool>, Promise<String>) in
-            let integer = Promise(value: 1)
-            let boolean = Promise(value: true)
-            let string = Promise(value: "yes")
-            return (integer, boolean, string)
-        }.then { integer, boolean, string -> Void in
-            XCTAssertEqual(1, integer)
-            XCTAssertEqual(true, boolean)
-            XCTAssertEqual("yes", string)
-            ex.fulfill()
+        getPromises() { a, b, c, _, _, first in
+            first.then { () -> (Promise<Bool>, Promise<Int>, Promise<String>) in
+                return (a, b, c)
+            }.then { aVal, bVal, cVal -> Void in
+                XCTAssertEqual(a.value, aVal)
+                XCTAssertEqual(b.value, bVal)
+                XCTAssertEqual(c.value, cVal)
+                ex.fulfill()
+            }
         }
 
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testQuadruplePromisesTuple() {
+    func testThenReturningQuadruplePromisesTuple() {
         let ex = expectation(description: "promise tuple values returned")
 
-        _ = firstly {
-            Promise(value: ())
-        }.then { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>) in
-            let boolean = after(interval: 0.1).then { true }
-            let integer = Promise(value: 1)
-            let string = Promise(value: "success")
-            let integerTuple = after(interval: 0.1).then { (2, 3) }
-            return (boolean, integer, string, integerTuple)
-        }.then { (boolean, integer, string, integerTuple) -> Void in
-            XCTAssertEqual(true, boolean)
-            XCTAssertEqual(1, integer)
-            XCTAssertEqual("success", string)
-            XCTAssertEqual(2, integerTuple.0)
-            XCTAssertEqual(3, integerTuple.1)
-            ex.fulfill()
+        getPromises() { a, b, c, d, _, first in
+            first.then { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>) in
+                return (a, b, c, d)
+            }.then { (boolean, integer, string, integerTuple) -> Void in
+                XCTAssertEqual(a.value, boolean)
+                XCTAssertEqual(b.value, integer)
+                XCTAssertEqual(c.value, string)
+                XCTAssertEqual(d.value!.0, integerTuple.0)
+                XCTAssertEqual(d.value!.1, integerTuple.1)
+                ex.fulfill()
+            }
         }
 
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testQuintuplePromisesTuple() {
+    func testThenReturningQuintuplePromisesTuple() {
         let ex = expectation(description: "promise tuple values returned")
 
-        _ = firstly {
-            Promise(value: ())
-        }.then { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>, Promise<Double>) in
-            let boolean = after(interval: 0.1).then { true }
-            let integer = Promise(value: 1)
-            let string = Promise(value: "success")
-            let integerTuple = after(interval: 0.1).then { (2, 3) }
-            let double = Promise(value: 0.1)
-            return (boolean, integer, string, integerTuple, double)
-        }.then { (boolean, integer, string, integerTuple, double) -> Void in
-            XCTAssertEqual(true, boolean)
-            XCTAssertEqual(1, integer)
-            XCTAssertEqual("success", string)
-            XCTAssertEqual(2, integerTuple.0)
-            XCTAssertEqual(3, integerTuple.1)
-            XCTAssertEqual(0.1, double)
-            ex.fulfill()
+        getPromises { a, b, c, d, e, first in
+            first.then { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>, Promise<Double>) in
+                return (a, b, c, d, e)
+            }.then { (boolean, integer, string, integerTuple, double) -> Void in
+                XCTAssertEqual(a.value, boolean)
+                XCTAssertEqual(b.value, integer)
+                XCTAssertEqual(c.value, string)
+                XCTAssertEqual(d.value!.0, integerTuple.0)
+                XCTAssertEqual(d.value!.1, integerTuple.1)
+                XCTAssertEqual(e.value, double)
+                ex.fulfill()
+            }
         }
 
         waitForExpectations(timeout: 1, handler: nil)
     }
 
+    // test then tuples fail
 
-    func testNtuplePromisesFail(generator: (Promise<Void>, Promise<Any>, Promise<Any>) -> Promise<Void>) {
+    func testThenNtuplePromisesFail(generator: (Promise<Void>, Promise<Any>, Promise<Any>) -> Promise<Void>) {
         let ex = expectation(description: "")
 
         generator(after(interval: 0.1), Promise<Any>(value: 1), Promise<Any>(error: TestError.sthWrong)).then {
@@ -107,34 +90,183 @@ class PromiseTupleTests: XCTestCase {
                 XCTFail("Wrong error received")
             }
         }
+
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testDoublePromisesTupleFail() {
-        testNtuplePromisesFail { after, success, err in
+    func testThenDoublePromisesTupleFail() {
+        testThenNtuplePromisesFail { after, success, err in
             after.then { (err, success) }
                  .then { (_: Any, _: Any) in () } // hint to compiler, that tuple version of `then` shall be used
         }
     }
 
-    func testTriplePromisesTupleFail() {
-        testNtuplePromisesFail { after, success, err in
+    func testThenTriplePromisesTupleFail() {
+        testThenNtuplePromisesFail { after, success, err in
             after.then { (success, err, success) }
                  .then { (_: Any, _: Any, _: Any) in () }
         }
     }
 
-    func testQuadruplePromisesTupleFail() {
-        testNtuplePromisesFail { after, success, err in
+    func testThenQuadruplePromisesTupleFail() {
+        testThenNtuplePromisesFail { after, success, err in
             after.then { (err, err, err, success) }
                  .then { (_: Any, _: Any, _: Any, _: Any) in () }
         }
     }
 
-    func testQuintuplePromisesTupleFail() {
-        testNtuplePromisesFail { after, success, err in
+    func testThenQuintuplePromisesTupleFail() {
+        testThenNtuplePromisesFail { after, success, err in
             after.then { (success, success, err, err, success) }
                  .then { (_: Any, _: Any, _: Any, _: Any, _: Any) in () }
         }
     }
+
+    // test firstly tuples
+
+    func testFirstlyReturningPromise() {
+        let ex = expectation(description: "promise tuple values returned")
+
+        firstly { () -> Promise<Bool> in
+            return Promise(value: true)
+        }.then { val -> Void in
+            XCTAssertEqual(val, true)
+            ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFirstlyReturningDoublePromisesTuple() {
+
+        let ex = expectation(description: "promise tuple values returned")
+
+        getPromises { a, b, _, _, _, _ in
+            firstly { () -> (Promise<Bool>, Promise<Int>) in
+                return (a, b)
+            }.then { (aVal: Bool, bVal: Int) -> Void in
+                XCTAssertEqual(aVal, a.value)
+                XCTAssertEqual(bVal, b.value)
+                ex.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFirstlyReturningTriplePromisesTuple() {
+
+        let ex = expectation(description: "promise tuple values returned")
+
+        getPromises { a, b, c, _, _, _ in
+            firstly { () -> (Promise<Bool>, Promise<Int>, Promise<String>) in
+                return (a, b, c)
+            }.then { (aVal: Bool, bVal: Int, cVal: String) -> Void in
+                XCTAssertEqual(aVal, a.value)
+                XCTAssertEqual(bVal, b.value)
+                XCTAssertEqual(cVal, c.value)
+                ex.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFirstlyReturningQuadruplePromisesTuple() {
+
+        let ex = expectation(description: "promise tuple values returned")
+
+        getPromises { a, b, c, d, _, _ in
+            firstly { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>) in
+                return (a, b, c, d)
+            }.then { (aVal: Bool, bVal: Int, cVal: String, dVal: (Int, Int)) -> Void in
+                XCTAssertEqual(aVal, a.value)
+                XCTAssertEqual(bVal, b.value)
+                XCTAssertEqual(cVal, c.value)
+                XCTAssertEqual(dVal.0, d.value!.0)
+                XCTAssertEqual(dVal.1, d.value!.1)
+                ex.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+
+    func testFirstlyReturningQuintuplePromisesTuple() {
+
+        let ex = expectation(description: "promise tuple values returned")
+
+        getPromises { a, b, c, d, e, _ in
+            firstly { () -> (Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>, Promise<Double>) in
+                return (a, b, c, d, e)
+            }.then { (aVal: Bool, bVal: Int, cVal: String, dVal: (Int, Int), eVal: Double) -> Void in
+                XCTAssertEqual(aVal, a.value)
+                XCTAssertEqual(bVal, b.value)
+                XCTAssertEqual(cVal, c.value)
+                XCTAssertEqual(dVal.0, d.value!.0)
+                XCTAssertEqual(dVal.1, d.value!.1)
+                XCTAssertEqual(eVal, e.value)
+                ex.fulfill()
+            }
+
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    // test firstly fail
+    func testFirstlyNtuplePromisesFail(generator: (Promise<Void>, Promise<Any>, Promise<Any>) -> Promise<Void>) {
+        let ex = expectation(description: "")
+
+        generator(after(interval: 0.1), Promise<Any>(value: 1), Promise<Any>(error: TestError.sthWrong)).then {
+            XCTFail("Then called instead of `catch`")
+        }.catch { e in
+            if case TestError.sthWrong = e {
+                ex.fulfill()
+            } else {
+                XCTFail("Wrong error received")
+            }
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testFirstlyDoublePromisesTupleFail() {
+        testFirstlyNtuplePromisesFail { after, success, err in
+            firstly { (err, success) }.then { (_: Any, _: Any) in () }
+        }
+    }
+
+    func testFirstlyTriplePromisesTupleFail() {
+        testFirstlyNtuplePromisesFail { after, success, err in
+            firstly { (success, err, success) }.then { (_: Any, _: Any, _: Any) in () }
+        }
+    }
+
+    func testFirstlyQuadruplePromisesTupleFail() {
+        testFirstlyNtuplePromisesFail { after, success, err in
+            firstly { (err, err, err, success) }.then { (_: Any, _: Any, _: Any, _: Any) in () }
+        }
+    }
+
+    func testFirstlyQuintuplePromisesTupleFail() {
+        testFirstlyNtuplePromisesFail { after, success, err in
+            firstly { (success, success, err, err, success) }.then { (_: Any, _: Any, _: Any, _: Any, _: Any) in () }
+        }
+    }
+}
+
+fileprivate enum TestError: Error {
+    case sthWrong
+}
+
+fileprivate func getPromises(callback: ((Promise<Bool>, Promise<Int>, Promise<String>, Promise<(Int, Int)>, Promise<Double>, Promise<Void>)) -> Void) {
+    let boolean = after(interval: 0.1).then { true }
+    let integer = Promise(value: 1)
+    let string = Promise(value: "success")
+    let integerTuple = after(interval: 0.1).then { (2, 3) }
+    let double = Promise(value: 0.1)
+    let empty = Promise(value: ())
+    callback(boolean, integer, string, integerTuple, double, empty)
 }


### PR DESCRIPTION
Add support for promises returning tuples of promises (#560)

- Supported up to 5 promises in tuples
- Supported 4 & 5 promises in `when` -> `when(fulfilled: p1, p2, p3, p4, p5)`

I had to add new `pipe` function that executes on provided dispatch queue. That's because I re-use`when` internally, and it is always run on `zalgo`.


Sidenote:
I don't check if in returned tuple there is originating promise itself (A+ 2.3.1). That's would not be allowed by compiler:
```
var promise<(Int, Int)> = somePromise.then { _ -> (Promise<Int>, Promise<Int>) in
    return (promise, promise) // fails
}
```
unless you do:
```
var promise<(Int, Int)> = somePromise.then { _ -> (Promise<Int>, Promise<Int>) in
    return (promise.asVoid().then {0}, promise.asVoid().then {0})
}
```
which we don't prevent anyway.