### PR TITLE
add AnyPromise+Private.h import into PMKCallVariadicBlock.m

### DIFF
--- a/Sources/PMKCallVariadicBlock.m
+++ b/Sources/PMKCallVariadicBlock.m
@@ -2,6 +2,7 @@
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSError.h>
 #import <Foundation/NSException.h>
+#import "AnyPromise+Private.h"
 #import "NSMethodSignatureForBlock.m"
 #import <PromiseKit/Umbrella.h>
 #import <PromiseKit/PromiseKit.h>


### PR DESCRIPTION
Header `AnyPromise+Private.h` is missing in `PMKCallVariadicBlock.m` which may cause compile error like this

```
Pods/PromiseKit/Sources/PMKCallVariadicBlock.m:114:16: error: implicit declaration of function 'PMKProcessUnhandledException' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        return PMKProcessUnhandledException(thrown);
```

This header already added into the master branch https://github.com/mxcl/PromiseKit/blob/master/Sources/PMKCallVariadicBlock.m#L4
But since we are using `swift-2.x` branch, so add the import into this branch as well.

@mxcl, could you take a look? Thanks