### PR TITLE
Update Readme with new example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -117,6 +117,20 @@ func avatar() -> Promise<UIImage> {
 }
 ```
 
+You can easily create a new, pending promise.
+```
+func fetchAvatar(user: String) -> Promise<UIImage> {
+    return Promise { fulfill, reject in
+        MyWebHelper.GET("\(user)/avatar") { data, err in
+            guard let data = data else { return reject(err) }
+            guard let img = UIImage(data: data) else { return reject(MyError.InvalidImage) }
+            guard let img.size.width > 0 else { return reject(MyError.ImageTooSmall) }
+            fulfill(img)
+        }
+    }
+}
+```
+
 ## Continue Learning…
 
 Complete and progressive learning guide at [promisekit.org].


### PR DESCRIPTION
This is a copy paste of the example of how to create a new pending promise from `Promise.swift`

I was surprised that this sort of example isn't front and center in the readme or the website docs given that it is a common requirement and quite a familiar API coming from other languages like Javascript