### PR TITLE
Added Promise.void

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Cartfile.resolved
 /.build
 .DS_Store
+DerivedData/

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -528,3 +528,19 @@ extension Promise where T: Collection {
         }
     }
 }
+
+extension Promise {
+    
+    /**
+     Returns a fulfilled Void promise.
+     
+     Usage example:
+ 
+     func doSomething() -> Promise<Void> {
+        return .void
+     }
+    */
+    public static var void: Promise<Void> {
+        return Promise<Void>(value: ())
+    }
+}

--- a/Tests/CorePromise/01_PromiseTests.swift
+++ b/Tests/CorePromise/01_PromiseTests.swift
@@ -75,6 +75,23 @@ class PromiseTests: XCTestCase {
 
         let bad = Promise(value: ()).then { Error.dummy }
     }
+    
+    func testVoidPromise() {
+        
+        let promise = Promise<Void>.void
+        XCTAssertTrue(promise.isFulfilled)
+        
+        guard let value = promise.value else {
+            return XCTFail("Promise should have a value")
+        }
+        
+        XCTAssertTrue(value is Void)
+        
+        // Sanity check to ensure `.void` can be accessed quickly
+        func doSomething() -> Promise<Void> {
+            return .void
+        }
+    }
 }
 
 private enum Error: Swift.Error {


### PR DESCRIPTION
@mxcl Fixes #532, related to my comment here: https://github.com/mxcl/PromiseKit/issues/532#issuecomment-264600471

I understand now why you said you were getting a compiler error: I was using `.void` in a context where `T` is already inferred:

```
func doSomething() -> Promise<Void> {
    return .void
}
```

What I assume you did is this:

```
let promise = Promise.void
```

which does indeed cause a compiler error because `T` cannot be inferred. If we want to support this kind of declaration, maybe having a non-generic helper namespace like `PromiseUtils` would help since we could use `PromiseUtils.void`. It seems super overkill for a small syntactic sugar addition like this though.

Let me know if you'd like to go with the current change, or add it somewhere else, or discard this altogether. I'm not super attached to having it in `PromiseKit` since it's an easy extension to write, and on the other hand I feel like a lot of people might need this.