### PR TITLE
Add @discardableResult to catch

### DIFF
--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -319,6 +319,7 @@ open class Promise<T> {
      - Parameter execute: The closure that executes when this promise resolves.
      - Returns: A new promise, resolved with this promise’s resolution.
      */
+	@discardableResult
     public func always(on q: DispatchQueue = .default, execute body: @escaping () -> Void) -> Promise {
         state.always(on: q) { resolution in
             body()


### PR DESCRIPTION
With PromiseKit 3 it is now possible to put always blocks at the end of the chain. The proposed change will remove the annoying  "Result to call is unused" warning from Xcode.