### PR TITLE
Fix when.swift to compile on Linux.

### DIFF
--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Dispatch
 
 private func _when<T>(_ promises: [Promise<T>]) -> Promise<Void> {
     let root = Promise<Void>.pending()


### PR DESCRIPTION
When building on Linux using SPM, `when.swift` fails with the following message:

```
/.build/checkouts/PromiseKit--3890273072143958801/Sources/when.swift:19:19: error: use of unresolved identifier 'DispatchQueue'
let barrier = DispatchQueue(label: "org.promisekit.barrier.when", attributes: .concurrent)
.build/checkouts/PromiseKit--3890273072143958801/Sources/when.swift:144:19: error: use of unresolved identifier 'DispatchQueue'
let barrier = DispatchQueue(label: "org.promisekit.barrier.when", attributes: [.concurrent])
.build/checkouts/PromiseKit--3890273072143958801/Sources/when.swift:229:19: error: use of unresolved identifier 'DispatchQueue'
let barrier = DispatchQueue(label: "org.promisekit.barrier.join", attributes: .concurrent)
```

As explained in [here](http://stackoverflow.com/a/40213241), it seems `import Dispatch` it is needed on Linux.

Tested on Ubuntu 14.04 with Swift 3.1.1 RELEASE.