### PR TITLE
Build PromisesKit on Linux using Docker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,37 @@
-language: objective-c
-osx_image: xcode8
-
-env:
-  - PLATFORM=Mac
-  - PLATFORM=iOS NAME='iPhone SE'
-  - PLATFORM=tvOS NAME='Apple TV 1080p'
-  - PLATFORM=watchOS
-
-before_install:
-  - if [ -n "$NAME" ]; then
-      export UUID=$(instruments -s | ruby -e "ARGF.each_line{ |ln| ln =~ /$NAME .* \[(.*)\]/; if \$1; puts(\$1); exit; end }");
-    fi
-
-script:
-  - set -o pipefail;
-    case $PLATFORM in
-    Mac)
-      xcodebuild -scheme PromiseKit -enableCodeCoverage YES test | xcpretty;;
-    iOS|tvOS)
-      open -a "simulator" --args -CurrentDeviceUDID "$UUID"
-      xcodebuild -scheme PromiseKit -destination "id=$UUID" -enableCodeCoverage YES test | xcpretty;;
-    watchOS)
-      xcodebuild -scheme PromiseKit -destination "name=Apple Watch - 38mm" | xcpretty;;
-    esac
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE=swift:3.1
+      before_install:
+        - docker pull $DOCKER_IMAGE
+      script: 
+        - set -o pipefail
+        - docker-compose run PromiseKit
+    - os: osx
+      language: objective-c
+      osx_image: xcode8
+      env:
+        - PLATFORM=Mac
+        - PLATFORM=iOS NAME='iPhone SE'
+        - PLATFORM=tvOS NAME='Apple TV 1080p'
+        - PLATFORM=watchOS
+      before_install:
+        - if [ -n "$NAME" ]; then
+            export UUID=$(instruments -s | ruby -e "ARGF.each_line{ |ln| ln =~ /$NAME .* \[(.*)\]/; if \$1; puts(\$1); exit; end }");
+          fi
+      script:
+        - set -o pipefail;
+          case $PLATFORM in
+          Mac)
+            xcodebuild -scheme PromiseKit -enableCodeCoverage YES test | xcpretty;;
+          iOS|tvOS)
+            open -a "simulator" --args -CurrentDeviceUDID "$UUID"
+            xcodebuild -scheme PromiseKit -destination "id=$UUID" -enableCodeCoverage YES test | xcpretty;;
+          watchOS)
+            xcodebuild -scheme PromiseKit -destination "name=Apple Watch - 38mm" | xcpretty;;
+          esac
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+PromiseKit:
+  image: swift:3.1
+  volumes:
+    - .:/root/PromiseKit
+  command: bash -c "cd /root/PromiseKit && swift build"


### PR DESCRIPTION
As seen in #661 without CI on Linux, Promises Kit becomes a bit fragile on for its use on Swift Server Side project.

## What's in this Pull Request?

* The use of [docker-compose](https://docs.docker.com/compose/overview/) for easily build PromisesKit on a Linux container. For more information about Docker please see official [docs](https://www.docker.com/).

* Update Travis to not only build on mac OS, but also on Linux environment. So if one of the two fails the build fails.

