### PR TITLE
expand the ObjC AnyPromise interface for catching

### DIFF
--- a/Sources/AnyPromise+Private.h
+++ b/Sources/AnyPromise+Private.h
@@ -27,7 +27,7 @@
 
 @interface AnyPromise (Swift)
 - (AnyPromise * __nonnull)__thenOn:(__nonnull dispatch_queue_t)q execute:(id __nullable (^ __nonnull)(id __nullable))body;
-- (AnyPromise * __nonnull)__catchWithPolicy:(PMKCatchPolicy)policy execute:(id __nullable (^ __nonnull)(id __nullable))body;
+- (AnyPromise * __nonnull)__catchOn:(__nonnull dispatch_queue_t)q withPolicy:(PMKCatchPolicy)policy execute:(id __nullable (^ __nonnull)(id __nullable))body;
 - (AnyPromise * __nonnull)__alwaysOn:(__nonnull dispatch_queue_t)q execute:(void (^ __nonnull)(void))body;
 - (void)__pipe:(void(^ __nonnull)(__nullable id))body;
 - (AnyPromise * __nonnull)initWithResolverBlock:(void (^ __nonnull)(PMKResolver __nonnull))resolver;

--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -101,6 +101,35 @@ typedef NS_ENUM(NSInteger, PMKCatchPolicy) {
 #endif
 
 /**
+ The provided block is executed when the receiver is rejected.
+ 
+ Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
+ 
+ The provided block always runs on the global background queue.
+ 
+ @warning *Note* Cancellation errors are not caught.
+ 
+ @warning *Note* Since catch is a c++ keyword, this method is not available in Objective-C++ files. Instead use catchWithPolicy.
+ 
+ @see catchWithPolicy
+ */
+- (AnyPromise * __nonnull(^ __nonnull)(id __nonnull))catchInBackground NS_REFINED_FOR_SWIFT;
+
+
+/**
+ The provided block is executed when the receiver is rejected.
+ 
+ Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
+ 
+ The provided block always runs on queue provided.
+ 
+ @warning *Note* Cancellation errors are not caught.
+ 
+ @see catchWithPolicy
+ */
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))catchOn NS_REFINED_FOR_SWIFT;
+
+/**
  The provided block is executed when the receiver is rejected with the specified policy.
 
  Specify the policy with which to catch as the first parameter to your block. Either for all errors, or all errors *except* cancellation errors.
@@ -108,6 +137,17 @@ typedef NS_ENUM(NSInteger, PMKCatchPolicy) {
  @see catch
 */
 - (AnyPromise * __nonnull(^ __nonnull)(PMKCatchPolicy, id __nonnull))catchWithPolicy NS_REFINED_FOR_SWIFT;
+
+/**
+ The provided block is executed when the receiver is rejected with the specified policy.
+ 
+ Specify the policy with which to catch as the first parameter to your block. Either for all errors, or all errors *except* cancellation errors.
+ 
+ The provided block always runs on queue provided.
+
+ @see catch
+ */
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, PMKCatchPolicy, id __nonnull))catchOnWithPolicy NS_REFINED_FOR_SWIFT;
 
 /**
  The provided block is executed when the receiver is resolved.

--- a/Sources/AnyPromise.m
+++ b/Sources/AnyPromise.m
@@ -38,9 +38,33 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
     };
 }
 
+- (AnyPromise *(^)(dispatch_queue_t, id))catchOn {
+    return ^(dispatch_queue_t q, id block) {
+        return [self __catchOn:q withPolicy:PMKCatchPolicyAllErrorsExceptCancellation execute:^(id obj) {
+            return PMKCallVariadicBlock(block, obj);
+        }];
+    };
+}
+
 - (AnyPromise *(^)(id))catch {
     return ^(id block) {
-        return [self __catchWithPolicy:PMKCatchPolicyAllErrorsExceptCancellation execute:^(id obj) {
+        return [self __catchOn:PMKDefaultDispatchQueue() withPolicy:PMKCatchPolicyAllErrorsExceptCancellation execute:^(id obj) {
+            return PMKCallVariadicBlock(block, obj);
+        }];
+    };
+}
+
+- (AnyPromise *(^)(id))catchInBackground {
+    return ^(id block) {
+        return [self __catchOn:dispatch_get_global_queue(0, 0) withPolicy:PMKCatchPolicyAllErrorsExceptCancellation execute:^(id obj) {
+            return PMKCallVariadicBlock(block, obj);
+        }];
+    };
+}
+
+- (AnyPromise *(^)(dispatch_queue_t, PMKCatchPolicy, id))catchOnWithPolicy {
+    return ^(dispatch_queue_t q, PMKCatchPolicy policy, id block) {
+        return [self __catchOn:q withPolicy:policy execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -48,7 +72,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(PMKCatchPolicy, id))catchWithPolicy {
     return ^(PMKCatchPolicy policy, id block) {
-        return [self __catchWithPolicy:policy execute:^(id obj) {
+        return [self __catchOn:PMKDefaultDispatchQueue() withPolicy:policy execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };

--- a/Sources/AnyPromise.swift
+++ b/Sources/AnyPromise.swift
@@ -206,9 +206,9 @@ import Foundation
         })
     }
 
-    @objc func __catchWithPolicy(_ policy: CatchPolicy, execute body: @escaping (Any?) -> Any?) -> AnyPromise {
+    @objc func __catchOn(_ q: DispatchQueue, withPolicy policy: CatchPolicy, execute body: @escaping (Any?) -> Any?) -> AnyPromise {
         return AnyPromise(sealant: { resolve in
-            state.catch(on: .default, policy: policy, else: resolve) { err in
+            state.catch(on: q, policy: policy, else: resolve) { err in
                 makeHandler(body, resolve)(err as NSError)
             }
         })


### PR DESCRIPTION
I've expanded the ObjC AnyPromise interface by adding the following methods:
```
- (AnyPromise * __nonnull(^ __nonnull)(id __nonnull))catchInBackground NS_REFINED_FOR_SWIFT;
- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))catchOn NS_REFINED_FOR_SWIFT;
- (AnyPromise * __nonnull(^ __nonnull)(PMKCatchPolicy, id __nonnull))catchWithPolicy NS_REFINED_FOR_SWIFT;
```
I also added 2 tests for the new methods.