### PR TITLE
Add NSUserCancelledError to cancelled error identifiers

### DIFF
--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -128,6 +128,7 @@ extension NSError {
 
 private var cancelledErrorIdentifiers = Set([
     ErrorPair(PMKErrorDomain, PMKOperationCancelled),
+    ErrorPair(NSCocoaErrorDomain, NSUserCancelledError),
     ErrorPair(NSURLErrorDomain, NSURLErrorCancelled),
 ])
 


### PR DESCRIPTION
Implements #680.

I saw the cancellation tests but it didn't seem like any were exhaustively testing the content of `cancelledErrorIdentifiers`, so I didn't add any tests. Happy to add something if it's appropriate.