### PR TITLE
Fix syntax issues in `attempt` example

### DIFF
--- a/Documentation/CommonPatterns.md
+++ b/Documentation/CommonPatterns.md
@@ -241,17 +241,19 @@ need to cancel the underlying task!
 ## Retry / Polling
 
 ```swift
-func attempt<T>(interdelay: DispatchTimeInterval = .seconds(2), maxRepeat: Int = 3, source: () -> Promise<T>) -> Promise<T>
+func attempt<T>(interdelay: TimeInterval = 2.0, maxRepeat: Int = 3, body: @escaping () -> Promise<T>) -> Promise<T> {
     var attempts = 0
     func attempt() -> Promise<T> {
         attempts += 1
         return body().recover { error -> Promise<T> in
             guard attempts < maxRepeat else { throw error }
+
             return after(interval: interdelay).then {
                 return attempt()
             }
         }
     }
+
     return attempt()
 }
 

--- a/Documentation/CommonPatterns.md
+++ b/Documentation/CommonPatterns.md
@@ -241,7 +241,7 @@ need to cancel the underlying task!
 ## Retry / Polling
 
 ```swift
-func attempt<T>(interdelay: TimeInterval = 2.0, maxRepeat: Int = 3, body: @escaping () -> Promise<T>) -> Promise<T> {
+func attempt<T>(interdelay: DispatchTimeInterval = .seconds(2), maxRepeat: Int = 3, body: @escaping () -> Promise<T>) -> Promise<T> {
     var attempts = 0
     func attempt() -> Promise<T> {
         attempts += 1


### PR DESCRIPTION
I just ended up using the `attempt` example in some code, but had to make some syntactical fix-ups to get it to work and figured I'd send them back your way:

- `after` takes a `TimeInterval`, not a `DispatchTimeInterval`
- The signature referred to `source` instead of `body` (which needed to be marked `@escaping`)
- Missing `{`