### PR TITLE
Fix potential error in sample code of Getting Started

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -255,7 +255,7 @@ func fetch() -> Promise<String> {
             if let result = result {
                 fulfill(result)
             } else if let error = error {
-                fulfill(error)
+                reject(error)
             } else {
                 reject(PMKError.invalidCallingConvention)
                 // ^^ we provide this error so that all paths are handled, even


### PR DESCRIPTION
Hello, 

I’m discovering PromiseKit (it’s been on my todolist for a long time). So I’m reading the « Getting started », and I think there is a typo in the code to create our own Promise. Indeed, in the case of an error, the sample code call `fulfill(error)`. But I think it should be `reject(error)`. 

It may be the result of a misunderstanding from me. If it is: I’m sorry ! 

Thanks for your good work ! 