### PR TITLE
Pure-swift hang() and tests.

### DIFF
--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C42F31B1FCF86320051309C /* 03_HangTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C42F3191FCF86240051309C /* 03_HangTests.swift */; };
+		0CC3AF2B1FCF84F7000E98C9 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC3AF2A1FCF84F7000E98C9 /* hang.swift */; };
 		49A5584D1DC5185900E4D01B /* 03_WrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A5584B1DC5172F00E4D01B /* 03_WrapTests.swift */; };
 		6314112B1D5978D700E24B9E /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B0AC571D595E1B00FA21D9 /* PromiseKit.framework */; };
 		631411311D5978EB00E24B9E /* PMKDefaultDispatchQueueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635D641B1D59635300BC0AF5 /* PMKDefaultDispatchQueueTest.swift */; };
@@ -102,6 +104,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0C42F3191FCF86240051309C /* 03_HangTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = 03_HangTests.swift; path = Tests/CorePromise/03_HangTests.swift; sourceTree = "<group>"; };
+		0CC3AF2A1FCF84F7000E98C9 /* hang.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = hang.swift; path = Sources/hang.swift; sourceTree = "<group>"; };
 		49A5584B1DC5172F00E4D01B /* 03_WrapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = 03_WrapTests.swift; path = Tests/CorePromise/03_WrapTests.swift; sourceTree = "<group>"; };
 		630019221D596292003B4E30 /* PMKCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6314112F1D5978D700E24B9E /* PMKDispatchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKDispatchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -255,6 +259,7 @@
 		6317518A1D59765700A9DDDC /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				0C42F3191FCF86240051309C /* 03_HangTests.swift */,
 				635D64071D59635300BC0AF5 /* 01_AnyPromiseTests.m */,
 				635D64081D59635300BC0AF5 /* 01_PromiseTests.swift */,
 				635D64091D59635300BC0AF5 /* 02_CancellationTests.swift */,
@@ -387,6 +392,7 @@
 		63B912AC1F1E663E00D49110 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				0CC3AF2A1FCF84F7000E98C9 /* hang.swift */,
 				63B0AC621D595E6300FA21D9 /* after.swift */,
 				63B912A91F1D7B1300D49110 /* firstly.swift */,
 				636A29241F1C3089001229C2 /* race.swift */,
@@ -550,6 +556,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0C42F31B1FCF86320051309C /* 03_HangTests.swift in Sources */,
 				635D641E1D59635300BC0AF5 /* 02_CancellationTests.swift in Sources */,
 				635D64221D59635300BC0AF5 /* 02_ZalgoTests.swift in Sources */,
 				635D64211D59635300BC0AF5 /* 02_PMKManifoldTests.m in Sources */,
@@ -630,6 +637,7 @@
 				63B0AC891D595E6300FA21D9 /* hang.m in Sources */,
 				63B0AC831D595E6300FA21D9 /* AnyPromise.swift in Sources */,
 				63B0AC871D595E6300FA21D9 /* Error.swift in Sources */,
+				0CC3AF2B1FCF84F7000E98C9 /* hang.swift in Sources */,
 				63B0AC7F1D595E6300FA21D9 /* after.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/hang.swift
+++ b/Sources/hang.swift
@@ -1,0 +1,50 @@
+import Foundation
+import CoreFoundation
+
+/**
+ Suspends the active thread waiting on the provided promise.
+
+ Useful when an application's main thread should not terminate before the promise is resolved
+ (e.g. commandline applications).
+
+ - Returns: The value of the provided promise once resolved.
+ - Throws: An error, should the promise be resolved with an error.
+ - SeeAlso: `wait()`
+*/
+public func hang<T>(_ promise: Promise<T>) throws -> T {
+#if os(OSX)
+    // isMainThread is not yet implemented on Linux.
+    guard Thread.isMainThread else {
+        // hang doesn't make sense on threads that aren't the main thread.
+        // use `.wait()` on those threads.
+        fatalError("Only call hang() on the main thread.")
+    }
+    let runLoopMode: CFRunLoopMode = CFRunLoopMode.defaultMode
+#else
+    let runLoopModeRaw = RunLoopMode.defaultRunLoopMode.rawValue._bridgeToObjectiveC()
+    let runLoopMode: CFString = unsafeBitCast(runLoopModeRaw, to: CFString.self)
+#endif
+
+    if promise.isPending {
+        var context = CFRunLoopSourceContext()
+        let runLoop = CFRunLoopGetCurrent()
+        let runLoopSource = CFRunLoopSourceCreate(nil, 0, &context)
+        CFRunLoopAddSource(runLoop, runLoopSource, runLoopMode)
+
+        _ = promise.ensure {
+            CFRunLoopStop(runLoop)
+        }
+
+        while promise.isPending {
+            CFRunLoopRun()
+        }
+        CFRunLoopRemoveSource(runLoop, runLoopSource, runLoopMode)
+    }
+
+    switch promise.result! {
+    case .rejected(let error):
+        throw error
+    case .fulfilled(let value):
+        return value
+    }
+}

--- a/Sources/hang.swift
+++ b/Sources/hang.swift
@@ -12,17 +12,17 @@ import CoreFoundation
  - SeeAlso: `wait()`
 */
 public func hang<T>(_ promise: Promise<T>) throws -> T {
-#if os(OSX)
+#if os(Linux)
     // isMainThread is not yet implemented on Linux.
+    let runLoopModeRaw = RunLoopMode.defaultRunLoopMode.rawValue._bridgeToObjectiveC()
+    let runLoopMode: CFString = unsafeBitCast(runLoopModeRaw, to: CFString.self)
+#else
     guard Thread.isMainThread else {
         // hang doesn't make sense on threads that aren't the main thread.
         // use `.wait()` on those threads.
         fatalError("Only call hang() on the main thread.")
     }
     let runLoopMode: CFRunLoopMode = CFRunLoopMode.defaultMode
-#else
-    let runLoopModeRaw = RunLoopMode.defaultRunLoopMode.rawValue._bridgeToObjectiveC()
-    let runLoopMode: CFString = unsafeBitCast(runLoopModeRaw, to: CFString.self)
 #endif
 
     if promise.isPending {

--- a/Tests/CorePromise/03_HangTests.swift
+++ b/Tests/CorePromise/03_HangTests.swift
@@ -1,0 +1,38 @@
+import PromiseKit
+import XCTest
+
+class HangTests: XCTestCase {
+    func test() {
+        let ex = expectation(description: "block executed")
+        do {
+            let value = try hang(after(seconds: 0.02).then { _ -> Promise<Int> in
+                ex.fulfill()
+                return Promise(value: 1)
+            })
+            XCTAssertEqual(value, 1)
+        } catch {
+            XCTFail("Unexpected error")
+        }
+        waitForExpectations(timeout: 0)
+    }
+
+    enum Error: Swift.Error {
+        case test
+    }
+
+    func testError() {
+        var value = 0
+        do {
+            _ = try hang(after(seconds: 0.02).done {
+                value = 1
+                throw Error.test
+            })
+            XCTAssertEqual(value, 1)
+        } catch Error.test {
+            return
+        } catch {
+            XCTFail("Unexpected error (expected Error.test)")
+        }
+        XCTFail("Expected error but no error was thrown")
+    }
+}


### PR DESCRIPTION
Hi! I've been writing some commandline tools in Swift and wanted to leverage promises; I need to ensure the command doesn't terminate before the promises resolve. After reading #423, here's a ~port of PMKHang to Swift.

Tested using Xcode 8.3.3 / Swift 3.1 on macOS and Swift 4.0.2 on Ubuntu 14.04.