### PR TITLE
Fixes Xcode 9.1 warnings

### DIFF
--- a/Sources/PMKPromise+Until.m
+++ b/Sources/PMKPromise+Until.m
@@ -11,7 +11,7 @@
 + (PMKPromise *)until:(id (^)(void))blockReturningPromises catch:(id)failHandler
 {
     return [PMKPromise new:^(PMKPromiseFulfiller fulfill, PMKPromiseRejecter reject){
-        __block void (^block)() = ^{
+        __block void (^block)(void) = ^{
             PMKPromise *next = [self when:blockReturningPromises()];
             next.then(^(id o){
                 fulfill(o);

--- a/Sources/PromiseKit/fwd.h
+++ b/Sources/PromiseKit/fwd.h
@@ -5,7 +5,7 @@
 @class NSOperationQueue;
 @class PMKPromise;
 
-extern NSOperationQueue *PMKOperationQueue();
+extern NSOperationQueue *PMKOperationQueue(void);
 
 #define PMK_DEPRECATED(msg) __attribute__((deprecated(msg)))
 


### PR DESCRIPTION
Hi!  Looks like XCode has tightened up their warnings again and you have to now specify that a function or block takes no args rather than just using `()`

Some background and links over here: https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9


