### PR TITLE
Fix syntax errors in Cancellation documentation

### DIFF
--- a/Documentation/CommonPatterns.md
+++ b/Documentation/CommonPatterns.md
@@ -199,21 +199,22 @@ special error type that conforms to the `CancellableError` protocol.
 
 ```swift
 func foo() -> (Promise<Void>, cancel: () -> Void) {
+    let task = Task(…)
     var cancelme = false
 
     let promise = Promise<Void> { fulfill, reject in
-        let task = Task(…)
-        let cancel = {
-            cancelme = true
-            task.cancel()
-            reject(NSError.cancelledError)
-        }
         task.completion = { value in
             guard !cancelme else { reject(NSError.cancelledError) }
             fulfill(value)
+        }
         task.start()
     }
-    
+
+    let cancel = {
+        cancelme = true
+        task.cancel()
+    }
+
     return (promise, cancel)
 }
 ```


### PR DESCRIPTION
In the current documentation for Cancellation, I noticed that `cancel` was out of scope for the return, and a brace was missing for `task.completion`.

I reworked the example a bit to fix the errors. The new example assumes that `task` invokes its completion block when it is cancelled, since `reject` is now out of scope for `cancel` but in scope for `completion`.