### PR TITLE
fix NSURLConnection+PromiseKit block warning

### DIFF
--- a/Sources/NSURLConnection+PromiseKit.m
+++ b/Sources/NSURLConnection+PromiseKit.m
@@ -97,7 +97,7 @@ NSString const*const PMKURLErrorFailingData = PMKURLErrorFailingDataKey;
                 rejunk(error);
             };
 
-            NSStringEncoding (^stringEncoding)() = ^NSStringEncoding{
+            NSStringEncoding (^stringEncoding)(void) = ^NSStringEncoding{
                 id encodingName = [rsp textEncodingName];
                 if (encodingName) {
                     CFStringEncoding encoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)encodingName);


### PR DESCRIPTION
Hello,

Using the latest Objective-C version (1.7.4) I had a warning that might not have been seen by #759. I had this one with Xcode 9.2.