### PR TITLE
Fix build on Xcode 9.3

### DIFF
--- a/Sources/PMKPromise+When.m
+++ b/Sources/PMKPromise+When.m
@@ -40,9 +40,10 @@
 
     if ([promises isKindOfClass:[NSDictionary class]])
         return newPromise = [PMKPromise new:^(PMKPromiseFulfiller fulfiller, PMKPromiseRejecter rejecter){
+            NSDictionary *promiseDictionary = (NSDictionary *) promises;
             NSMutableDictionary *results = [NSMutableDictionary new];
-            for (id key in promises) {
-                PMKPromise *promise = promises[key];
+            for (id key in promiseDictionary) {
+                PMKPromise *promise = promiseDictionary[key];
                 if (![promise isKindOfClass:[PMKPromise class]])
                     promise = [PMKPromise promiseWithValue:promise];
                 promise.catch(rejecter(key));


### PR DESCRIPTION
It looks like Clang no longer allows object subscripting on id&lt;protocols&gt; if neither of protocols defines -objectForKeyedSubscript:.