### PR TITLE
Update GettingStarted.md

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -193,7 +193,7 @@ operation2 {
     result2 = $0
     group.leave()
 }
-group.completion = {
+group.notify(queue: .main) {
     finish(result1, result2)
 }
 ```


### PR DESCRIPTION
Fix DispatchGroup example under #when

Maybe the original was intended only to be pseudocode, but figured it's helpful to have the real code. Mostly for us. The code is even _less_ clear now!