### PR TITLE
Partially document v6 source code

### DIFF
--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -50,6 +50,22 @@ public class PMKFinalizer {
 
 
 public extension CatchMixin {
+    
+    /**
+     The provided closure executes when this promise rejects.
+     
+     Unlike `catch`, `recover` continues the chain provided the closure does not throw.
+     Use `recover` in circumstances where recovering the chain from certain errors is a possibility. For example:
+     
+         CLLocationManager.promise().recover { error in
+             guard error == CLError.unknownLocation else { throw error }
+             return .value(CLLocation.Chicago)
+         }
+     
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The handler to execute if this promise is rejected.
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
+     */
     func recover<U: Thenable>(on: DispatchQueue? = conf.Q.map, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) throws -> U) -> Promise<T> where U.T == T {
         let rp = Promise<U.T>(.pending)
         pipe {
@@ -126,7 +142,6 @@ public extension CatchMixin where T == Void {
      The provided closure executes when this promise rejects.
      
      This variant of `recover` ensures that no error is thrown from the handler, thus producing a Guarantee.
-     Note it is logically impossible for this to take a catchPolicy, thus allErrors are handled.
      
      - Parameter on: The queue to which the provided closure dispatches.
      - Parameter body: The handler to execute if this promise is rejected.
@@ -152,14 +167,7 @@ public extension CatchMixin where T == Void {
     /**
      The provided closure executes when this promise rejects.
      
-     Unlike `catch`, `recover` continues the chain provided the closure does not throw. Use `recover` in circumstances where recovering the chain from certain errors is a possibility. For example:
-     
-         CLLocationManager.promise().recover { error in
-             guard error == CLError.unknownLocation else { throw error }
-             return .value(CLLocation.Chicago)
-         }
-     
-     Note it is logically impossible for this to take a catchPolicy, thus allErrors are handled.
+     This variant of `recover` ensures that no error is thrown from the handler and allows specifying a catch policy.
      
      - Parameter on: The queue to which the provided closure dispatches.
      - Parameter body: The handler to execute if this promise is rejected.

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -4,6 +4,21 @@ public protocol CatchMixin: Thenable
 {}
 
 public extension CatchMixin {
+    
+    /**
+     The provided closure executes when this promise rejects.
+     
+     Rejecting a promise cascades: rejecting all subsequent promises (unless
+     recover is invoked) thus you will typically place your catch at the end
+     of a chain. Often utility promises will not have a catch, instead
+     delegating the error handling to the caller.
+     
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter policy: The default policy does not execute your handler for cancellation errors.
+     - Parameter execute: The handler to execute if this promise is rejected.
+     - Returns: A promise finalizer.
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
+     */
     @discardableResult
     func `catch`(on: DispatchQueue? = conf.Q.return, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) -> Void) -> PMKFinalizer {
         let finalizer = PMKFinalizer()
@@ -60,7 +75,16 @@ public extension CatchMixin {
         return rp
     }
 
-    /// recover into a Guarantee, note it is logically impossible for this to take a catchPolicy, thus allErrors are handled
+    /**
+     The provided closure executes when this promise rejects.
+     
+     This variant of `recover` requires the handler to return a Guarantee, thus it returns a Guarantee itself.
+     Note it is logically impossible for this to take a catchPolicy, thus allErrors are handled.
+     
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The handler to execute if this promise is rejected.
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
+     */
     @discardableResult
     func recover(on: DispatchQueue? = conf.Q.map, _ body: @escaping(Error) -> Guarantee<T>) -> Guarantee<T> {
         let rg = Guarantee<T>(.pending)
@@ -97,6 +121,17 @@ public extension CatchMixin {
 
 
 public extension CatchMixin where T == Void {
+    
+    /**
+     The provided closure executes when this promise rejects.
+     
+     This variant of `recover` ensures that no error is thrown from the handler, thus producing a Guarantee.
+     Note it is logically impossible for this to take a catchPolicy, thus allErrors are handled.
+     
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The handler to execute if this promise is rejected.
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
+     */
     @discardableResult
     func recover(on: DispatchQueue? = conf.Q.map, _ body: @escaping(Error) -> Void) -> Guarantee<Void> {
         let rg = Guarantee<Void>(.pending)
@@ -114,6 +149,22 @@ public extension CatchMixin where T == Void {
         return rg
     }
 
+    /**
+     The provided closure executes when this promise rejects.
+     
+     Unlike `catch`, `recover` continues the chain provided the closure does not throw. Use `recover` in circumstances where recovering the chain from certain errors is a possibility. For example:
+     
+         CLLocationManager.promise().recover { error in
+             guard error == CLError.unknownLocation else { throw error }
+             return .value(CLLocation.Chicago)
+         }
+     
+     Note it is logically impossible for this to take a catchPolicy, thus allErrors are handled.
+     
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The handler to execute if this promise is rejected.
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
+     */
     func recover(on: DispatchQueue? = conf.Q.map, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) throws -> Void) -> Promise<Void> {
         let rg = Promise<Void>(.pending)
         pipe {

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -117,6 +117,23 @@ public extension CatchMixin {
         return rg
     }
 
+    /**
+     The provided closure executes when this promise resolves, whether it rejects or not.
+     
+         firstly {
+            UIApplication.shared.networkActivityIndicatorVisible = true
+         }.done {
+            //…
+         }.ensure {
+            UIApplication.shared.networkActivityIndicatorVisible = false
+         }.catch {
+            //…
+         }
+     
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The closure that executes when this promise resolves.
+     - Returns: A new promise, resolved with this promise’s resolution.
+     */
     func ensure(on: DispatchQueue? = conf.Q.return, _ body: @escaping () -> Void) -> Promise<T> {
         let rp = Promise<T>(.pending)
         pipe { result in

--- a/Sources/Thenable.swift
+++ b/Sources/Thenable.swift
@@ -14,7 +14,7 @@ public extension Thenable {
      This allows chaining promises. The promise returned by the provided closure is resolved before the promise returned by this closure resolves.
      
      - Parameter on: The queue to which the provided closure dispatches.
-     - Parameter execute: The closure that executes when this promise fulfills. It must return a promise.
+     - Parameter body: The closure that executes when this promise fulfills. It must return a promise.
      - Returns: A new promise that resolves when the promise returned from the provided closure resolves. For example:
      
          URLSession.GET(url1).then { data in
@@ -50,7 +50,7 @@ public extension Thenable {
      This is like `then` but it requires the closure to return a non-promise.
      
      - Parameter on: The queue to which the provided closure dispatches.
-     - Parameter body: The closure that is executed when this Promise is fulfilled. It must return a non-promise.
+     - Parameter transform: The closure that is executed when this Promise is fulfilled. It must return a non-promise.
      - Returns: A new promise that is resolved with the value returned from the provided closure. For example:
      
          URLSession.GET(url).then { data -> Int in


### PR DESCRIPTION
Addresses some of https://github.com/mxcl/PromiseKit/issues/784

As advised, I took most of the documentation from the `v4` branch. I only added documentation for the core methods for now: `then / done / get / map / catch / recover / ensure` as well as the `Promise` class. Happy to helping documenting the rest in other PRs.

Let me know if this is on the right track.