### PR TITLE
Make when(_ guarantees:) generic

### DIFF
--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -253,11 +253,11 @@ public func when<T>(resolved promises: [Promise<T>]) -> Guarantee<[Result<T>]> {
 }
 
 /// Waits on all provided Guarantees.
-public func when(_ guarantees: Guarantee<Void>...) -> Guarantee<Void> {
+public func when<T>(_ guarantees: Guarantee<T>...) -> Guarantee<[T]> {
     return when(guarantees: guarantees)
 }
 
 // Waits on all provided Guarantees.
-public func when(guarantees: [Guarantee<Void>]) -> Guarantee<Void> {
-    return when(fulfilled: guarantees).recover{ _ in }.asVoid()
+public func when<T>(guarantees: [Guarantee<T>]) -> Guarantee<[T]> {
+    return when(fulfilled: guarantees).recover{ _ in }
 }


### PR DESCRIPTION
I tried this out and it seems to work fine. Is there a reason you restricted `when()` to Void guarantees that I'm missing?

I'd like to also provide equivalents for the `when(_:_:_:...)` helpers but that doesn't seem possible without introducing ambiguity.