### PR TITLE
The return of Zalgo

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -235,6 +235,17 @@ PromiseKit.conf.Q.map = .global()
 PromiseKit.conf.Q.return = .main  //NOTE this is the default
 ```
 
+Be very careful about setting either of these queues to `nil`.  It has the
+effect of running *immediately*, and this is not what you usually want to do in
+your application.  This is, however, useful when you are running specs, and want
+your promises to resolve immediately (basically the same behavior as "stubbing"
+an HTTP request).
+
+```swift
+// in your test suite setup code
+PromiseKit.conf.Q.map = nil
+PromiseKit.conf.Q.return = nil
+```
 
 ## How do I use PromiseKit server-side?
 

--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -2,7 +2,7 @@ import Dispatch
 
 public struct PMKConfiguration {
     /// the default queues that promises handlers dispatch to
-    public var Q: (map: DispatchQueue?, return: DispatchQueue) = (map: DispatchQueue.main, return: DispatchQueue.main)
+    public var Q: (map: DispatchQueue?, return: DispatchQueue?) = (map: DispatchQueue.main, return: DispatchQueue.main)
 
     public var catchPolicy = CatchPolicy.allErrorsExceptCancellation
 }

--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -2,7 +2,7 @@ import Dispatch
 
 public struct PMKConfiguration {
     /// the default queues that promises handlers dispatch to
-    public var Q = (map: DispatchQueue.main, return: DispatchQueue.main)
+    public var Q: (map: DispatchQueue?, return: DispatchQueue) = (map: DispatchQueue.main, return: DispatchQueue.main)
 
     public var catchPolicy = CatchPolicy.allErrorsExceptCancellation
 }

--- a/Sources/Thenable.swift
+++ b/Sources/Thenable.swift
@@ -177,8 +177,8 @@ public extension Thenable {
                print(foo, " is Void")
            }
      */
-    func get(_ body: @escaping (T) throws -> Void) -> Promise<T> {
-        return map(on: PromiseKit.conf.Q.return) {
+    func get(on: DispatchQueue? = conf.Q.return, _ body: @escaping (T) throws -> Void) -> Promise<T> {
+        return map(on: on) {
             try body($0)
             return $0
         }


### PR DESCRIPTION
Supports

```
conf.Q.map = nil
```

This makes all promises to be run immediately instead of using async.
