### PR TITLE
Add ensureThen

### DIFF
--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -150,6 +150,38 @@ public extension CatchMixin {
     }
 
     /**
+     The provided closure executes when this promise resolves, whether it rejects or not.
+     The chain waits on the returned `Guarantee`.
+
+         firstly {
+             setup()
+         }.done {
+             //…
+         }.ensure {
+             teardown()
+         }.catch {
+             //…
+         }
+
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The closure that executes when this promise resolves.
+     - Returns: A new promise, resolved with this promise’s resolution.
+     */
+    func ensureThen(on: DispatchQueue? = conf.Q.return, _ body: @escaping () -> Guarantee<Void>) -> Promise<T> {
+        let rp = Promise<T>(.pending)
+        pipe { result in
+            on.async {
+                body().done {
+                    rp.box.seal(result)
+                }
+            }
+        }
+        return rp
+    }
+
+
+
+    /**
      Consumes the Swift unused-result warning.
      - Note: You should `catch`, but in situations where you know you don’t need a `catch`, `cauterize` makes your intentions clear.
      */

--- a/Tests/CorePromise/CatchableTests.swift
+++ b/Tests/CorePromise/CatchableTests.swift
@@ -213,6 +213,39 @@ extension CatchableTests {
         }
         wait(for: [ex], timeout: 10)
     }
+
+    func testEnsureThen_Error() {
+        let ex = expectation(description: "")
+
+        Promise.value(1).done {
+            XCTAssertEqual($0, 1)
+            throw Error.dummy
+        }.ensureThen {
+            after(seconds: 0.01)
+        }.catch {
+            XCTAssertEqual(Error.dummy, $0 as? Error)
+        }.finally {
+            ex.fulfill()
+        }
+
+        wait(for: [ex], timeout: 10)
+    }
+
+    func testEnsureThen_Value() {
+        let ex = expectation(description: "")
+
+        Promise.value(1).ensureThen {
+            after(seconds: 0.01)
+        }.done {
+            XCTAssertEqual($0, 1)
+        }.catch { _ in
+            XCTFail()
+        }.finally {
+            ex.fulfill()
+        }
+
+        wait(for: [ex], timeout: 10)
+    }
 }
 
 private enum Error: CancellableError {


### PR DESCRIPTION
Couldn’t have two variants of `ensure` without the dreaded ambiguity issues.

Sadly Swift cannot infer the type for multiline closures where there are two possible functions for it to match. :(

Refs #838 