### PR TITLE
Fix build issue in hang.swift

### DIFF
--- a/Sources/hang.swift
+++ b/Sources/hang.swift
@@ -13,7 +13,7 @@ import CoreFoundation
  - See: `wait()`
 */
 public func hang<T>(_ promise: Promise<T>) throws -> T {
-#if os(Linux)
+#if os(Linux) || os(Android)
     // isMainThread is not yet implemented on Linux.
     let runLoopModeRaw = RunLoopMode.defaultRunLoopMode.rawValue._bridgeToObjectiveC()
     let runLoopMode: CFString = unsafeBitCast(runLoopModeRaw, to: CFString.self)


### PR DESCRIPTION
Android does not have `CFRunLoopMode.xyz` (which breaks builds for that platform). Android is also a Linux variant, so this change fixes the semantic / functional issue there too.

It's possible this should be a defensive check on `#if os(iOS) || os(macOS) || os(tvOS)` instead, because the same issues apply to all non-darwin platforms. But personally I'd be fine with this as is.