### PR TITLE
Fixed build error in AnyPromise.m

### DIFF
--- a/Sources/AnyPromise.m
+++ b/Sources/AnyPromise.m
@@ -1,4 +1,8 @@
-#import <PromiseKit/PromiseKit-Swift.h>
+#if __has_include("PromiseKit-Swift.h")
+    #import "PromiseKit-Swift.h"
+#else
+    #import <PromiseKit/PromiseKit-Swift.h>
+#endif
 #import "PMKCallVariadicBlock.m"
 #import "AnyPromise+Private.h"
 #import "AnyPromise.h"


### PR DESCRIPTION
When installing PromiseKit 6 as a static library via CocoaPods.
The problem is described in the following issue - https://github.com/mxcl/PromiseKit/issues/825.