### PR TITLE
add lightweight generics support

### DIFF
--- a/Sources/PromiseKit/Promise.h
+++ b/Sources/PromiseKit/Promise.h
@@ -18,7 +18,7 @@
  @see [PromiseKit `then` Guide](http://promisekit.org/then/)
  @see [PromiseKit Chaining Guide](http://promisekit.org/chaining/)
 */
-@interface PMKPromise : NSObject
+@interface PMKPromise<ResultType> : NSObject
 
 /**
  The provided block is executed when its receiver is resolved.

--- a/Sources/PromiseKit/fwd.h
+++ b/Sources/PromiseKit/fwd.h
@@ -3,7 +3,7 @@
 @class NSError;
 @class NSString;
 @class NSOperationQueue;
-@class PMKPromise;
+@class PMKPromise<ResultType>;
 
 extern NSOperationQueue *PMKOperationQueue(void);
 

--- a/Tests/PMKPromise.test.m
+++ b/Tests/PMKPromise.test.m
@@ -32,7 +32,7 @@
 - (void)test_01_resolve {
     id ex1 = [self expectationWithDescription:@""];
 
-    PMKPromise *promise = [PMKPromise new:^(void (^f)(id), id r){
+    PMKPromise<NSNumber*> *promise = [PMKPromise new:^(void (^f)(id), id r){
         f(@1);
     }];
     promise.then(^(NSNumber *o){
@@ -49,7 +49,7 @@
 - (void)test_02_reject {
     id ex1 = [self expectationWithDescription:@""];
 
-    PMKPromise *promise = [PMKPromise new:^(id f, void (^r)(id)){
+    PMKPromise<NSNumber*> *promise = [PMKPromise new:^(id f, void (^r)(id)){
         r(@2);
     }];
     promise.then(^{
@@ -66,7 +66,7 @@
 - (void)test_03_throw {
     id ex1 = [self expectationWithDescription:@""];
 
-    PMKPromise *promise = [PMKPromise new:^(void (^f)(id), id r){
+    PMKPromise<NSNumber*> *promise = [PMKPromise new:^(void (^f)(id), id r){
         f(@2);
     }];
     promise.then(^{
@@ -85,7 +85,7 @@
 - (void)test_04_throw_doesnt_compromise_result {
     id ex1 = [self expectationWithDescription:@""];
 
-    PMKPromise *promise = [PMKPromise new:^(void (^f)(id), id r){
+    PMKPromise<NSNumber*> *promise = [PMKPromise new:^(void (^f)(id), id r){
         f(@4);
     }].then(^{
         @throw @4;


### PR DESCRIPTION
Hello,

This is a follow-up of #833, adding the ability to indicate `PMKPromise` result type.
This has no impact on runtime whatsoever, I followed [this blog post](https://miqu.me/blog/2015/06/09/adopting-objectivec-generics/) to implement it.

As you can see it is as straightforward as it can be, although there might be some way to improve this and use annotations inside the library's code.
I have not read the whole code base, so you're the one that knows @mxcl :)

From what I've understood, you're using `id` a lot, so determining the result type of a promise chain seems unfeasible.