### PR TITLE
Guarantee.thenMap which returns a Guarantee

### DIFF
--- a/Sources/Guarantee.swift
+++ b/Sources/Guarantee.swift
@@ -142,7 +142,7 @@ public extension Guarantee where T: Sequence {
         return then(on: on) {
             when(fulfilled: $0.map(transform))
         }
-        .recover { _ in return .value([]) }
+            .recover { fatalError( String(describing: $0)) }
     }
 }
 

--- a/Sources/Guarantee.swift
+++ b/Sources/Guarantee.swift
@@ -138,9 +138,9 @@ public extension Guarantee where T: Sequence {
      // $0 => [2,4,6]
      }
      */
-    func thenMap<U>(on: DispatchQueue? = conf.Q.map, _ transform: @escaping(T.Iterator.Element) throws -> Guarantee<U>) -> Guarantee<[U]> {
+    func thenMap<U>(on: DispatchQueue? = conf.Q.map, _ transform: @escaping(T.Iterator.Element) -> Guarantee<U>) -> Guarantee<[U]> {
         return then(on: on) {
-            when(fulfilled: try $0.map(transform))
+            when(fulfilled: $0.map(transform))
         }
         .recover { _ in return .value([]) }
     }

--- a/Sources/Guarantee.swift
+++ b/Sources/Guarantee.swift
@@ -125,6 +125,27 @@ public extension Guarantee {
     }
 }
 
+public extension Guarantee where T: Sequence {
+
+    /**
+     `Guarantee<[T]>` => `T` -> `Guarantee<U>` => `Guaranetee<[U]>`
+
+     firstly {
+     .value([1,2,3])
+     }.thenMap { integer in
+     .value(integer * 2)
+     }.done {
+     // $0 => [2,4,6]
+     }
+     */
+    func thenMap<U>(on: DispatchQueue? = conf.Q.map, _ transform: @escaping(T.Iterator.Element) throws -> Guarantee<U>) -> Guarantee<[U]> {
+        return then(on: on) {
+            when(fulfilled: try $0.map(transform))
+        }
+        .recover { _ in return .value([]) }
+    }
+}
+
 #if swift(>=3.1)
 public extension Guarantee where T == Void {
     convenience init() {

--- a/Tests/CorePromise/GuaranteeTests.swift
+++ b/Tests/CorePromise/GuaranteeTests.swift
@@ -18,10 +18,16 @@ class GuaranteeTests: XCTestCase {
     }
 
     func testThenMap() {
+
+        let ex = expectation(description: "")
+
         Guarantee.value([1, 2, 3])
             .thenMap { Guarantee.value($0 * 2) }
             .done { values in
                 XCTAssertEqual([2, 4, 6], values)
+                ex.fulfill()
         }
+
+        wait(for: [ex], timeout: 10)
     }
 }

--- a/Tests/CorePromise/GuaranteeTests.swift
+++ b/Tests/CorePromise/GuaranteeTests.swift
@@ -16,4 +16,12 @@ class GuaranteeTests: XCTestCase {
     func testWait() {
         XCTAssertEqual(after(.milliseconds(100)).map(on: nil){ 1 }.wait(), 1)
     }
+
+    func testThenMap() {
+        Guarantee.value([1, 2, 3])
+            .thenMap { Guarantee.value($0 * 2) }
+            .done { values in
+                XCTAssertEqual([2, 4, 6], values)
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a `thenMap` function to Guarantee that returns a Guarantee instead of a Promise.

Hopefully I've got it right. I've also added a test which passes.