### PR TITLE
Accept a queue in finally()

### DIFF
--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -45,8 +45,10 @@ public class PMKFinalizer {
     let pending = Guarantee<Void>.pending()
 
     /// `finally` is the same as `ensure`, but it is not chainable
-    public func finally(_ body: @escaping () -> Void) {
-        pending.guarantee.done(body)
+    public func finally(on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping () -> Void) {
+        pending.guarantee.done(on: on, flags: flags) {
+            body()
+        }
     }
 }
 


### PR DESCRIPTION
@mxcl I'm not entirely sure of the test I've included in the test suite. Since I saw two tests in the `testFinally()` test, I added the test for checking the DispatchQueue there too.

Let me know if there's a better way you'd like me to structure this.