### PR TITLE
Update 'Core' test target name to 'CorePromise'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,5 +26,5 @@ pkg.swiftLanguageVersions = [3, 4]
 pkg.targets = [
     pmk,
     .testTarget(name: "A+", dependencies: ["PromiseKit"]),
-    .testTarget(name: "Core", dependencies: ["PromiseKit"], path: "Tests/CorePromise"),
+    .testTarget(name: "CorePromise", dependencies: ["PromiseKit"], path: "Tests/CorePromise"),
 ]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 
 
-@testable import Core
+@testable import CorePromise
 @testable import A_
 import XCTest
 


### PR DESCRIPTION
More descriptive name avoids target conflicts during swift build process
when depending on multiple packages that also have a 'Core' target

I believe this was the only place a name change was necessary; I couldn't see anything in .travis.yml that named this target explicitly