### PR TITLE
Documentation copy editing, add more RxSwift info, fix asVoid() example

### DIFF
--- a/Documentation/CommonPatterns.md
+++ b/Documentation/CommonPatterns.md
@@ -1,13 +1,13 @@
-# Common Patterns
+# Common patterns
 
-One feature of promises that makes them so useful is that they are composable;
-enabling complex, yet safe asynchronous patterns that would otherwise be quite
-intimidating with traditional methods.
+One feature of promises that makes them particularly useful is that they are composable.
+This fact enables complex, yet safe, asynchronous patterns that would otherwise be quite
+intimidating when implemented with traditional methods.
 
 
 ## Chaining
 
-The most common pattern with promises is chaining:
+The most common pattern is chaining:
 
 ```swift
 firstly {
@@ -24,17 +24,17 @@ firstly {
 }
 ```
 
-If you return a promise in a `then` the next `then` *waits* on that promise
+If you return a promise in a `then`, the next `then` *waits* on that promise
 before continuing. This is the essence of promises.
 
-Composing promises is easy, and they thus encourage you to develop great apps
-without fear for the typical spaghetti (and associated refactoring pains) of
+Promises are easy to compose, so they encourage you to develop highly asynchronous
+apps without fear of the spaghetti code (and associated refactoring pains) of
 asynchronous systems that use completion handlers.
 
 
-## APIs That Use Promises
+## APIs that use promises
 
-Promises are composable, return them instead of providing completion blocks:
+Promises are composable, so return them instead of accepting completion blocks:
 
 ```swift
 class MyRestAPI {
@@ -58,13 +58,13 @@ class MyRestAPI {
 }
 ```
 
-This way, your asynchronous systems can easily be engaged in chains all over
-your apps.
+This way, asynchronous chains can cleanly and seamlessly incorporate code from all over
+your app without violating architectural boundaries.
 
-> Note we provide [promises for Alamofire](https://github.com/PromiseKit/Alamofire-) too!
+> *Note*: We provide [promises for Alamofire](https://github.com/PromiseKit/Alamofire-) too!
 
 
-## Background Work
+## Background work
 
 ```swift
 class MyRestAPI {
@@ -82,19 +82,19 @@ class MyRestAPI {
 }
 ```
 
-All PromiseKit handlers take an `on` parameter allowing you to choose the queue
-the handler executes upon. The default is always the main queue.
+All PromiseKit handlers take an `on` parameter that lets you designate the dispatch queue
+on which to run the handler. The default is always the main queue.
 
 PromiseKit is *entirely* thread safe.
 
-> *Tip* with caution you can have all `then`, `map`, `compactMap`, etc. run on
-a background queue, see `PromiseKit.conf`. Note that we suggest only changing
-the queue for the `map` suite of functions, thus `done` and `catch` will
-continue to run on the main queue which is *usually* what you want.
+> *Tip*: With caution, you can have all `then`, `map`, `compactMap`, etc., run on
+a background queue. See `PromiseKit.conf`. Note that we suggest only changing
+the queue for the `map` suite of functions, so `done` and `catch` will
+continue to run on the main queue, which is *usually* what you want.
 
-## Failing Chains
+## Failing chains
 
-If an error occurs mid chain, simply throw:
+If an error occurs mid-chain, simply throw an error:
 
 ```swift
 firstly {
@@ -110,7 +110,8 @@ firstly {
 
 The error will surface at the next `catch` handler.
 
-Thus if you call a throwing function, you don't have to wrap it in a `do`:
+Since promises handle thrown errors, you don't have to wrap calls to throwing functions 
+in a `do` block unless you really want to handle the errors locally:
 
 ```swift
 foo().then { baz in
@@ -122,13 +123,13 @@ foo().then { baz in
 }
 ```
 
-> *Tip* with Swift you can define inline `enum Error` inside the function you
-are working at. This isn’t *great* coding practice, but it is better than
-avoiding throwing an error because you can’t be bothered to define a good global
+> *Tip*: Swift lets you define an inline `enum Error` inside the function you
+are working on. This isn’t *great* coding practice, but it's better than
+avoiding throwing an error because you couldn't be bothered to define a good global
 `Error` `enum`.
 
 
-## Abstracting Away Asychronicity
+## Abstracting away asychronicity
 
 ```swift
 var fetch = API.fetch()
@@ -158,14 +159,14 @@ func refresh() {
 }
 ```
 
-With promises you don’t need to worry about *when* your asynchronous operation
-finishes: act like it already has.
+With promises, you don’t need to worry about *when* your asynchronous operation
+finishes. Just act like it already has.
 
-> Above we can see that you can call `then` as many times on a promise as you
-> like, they will all be executed in the order they were added.
+Above, we see that you can call `then` as many times on a promise as you
+like. All the blocks will be executed in the order they were added.
 
 
-## Chaining Sequences
+## Chaining sequences
 
 When you have a series of tasks to perform on an array of data:
 
@@ -185,12 +186,13 @@ fade.done {
 }
 ```
 
-> Note *usually* you want `when()` since `when` executes all the promises in
-parallel and thus is much faster to complete. Use the above pattern in
-situations where tasks *must* be done sequentially; animation is a good example.
+> *Note*: You *usually* you want `when()`, since `when` executes all of its
+component promises in parallel and so completes much faster. Use the pattern 
+shown above in situations where tasks *must* be run sequentially; animation
+is a good example.
 
-We also provide `when(concurrently:)` which allows you to schedule more than
-one promise at a time if required.
+We also provide `when(concurrently:)`, which lets you schedule more than
+one promise at a time if you need to.
 
 ## Timeout
 
@@ -203,19 +205,19 @@ race(when(fulfilled: fetches).asVoid(), timeout).then {
 }
 ```
 
-`race` continues as soon as one of the promises it watches finishes.
+`race` continues as soon as one of the promises it is watching finishes.
 
-> Common pitfalls: ensure the promises you pass to `race` are the same type.
-> The easiest way to ensure this is using `asVoid()`.
+Make sure the promises you pass to `race` are all of the same type. The easiest way
+to ensure this is to use `asVoid()`.
 
-> Please note if any promise you pass rejects, then `race` will be rejected.
+Note that if any component promise rejects, the `race` will reject, too.
 
 
-# Minimum Duration
+# Minimum duration
 
-Sometimes you need something to take *at least* a certain amount of time (eg.
-you want to show a spinner for something, but if it shows for less than 0.3
-seconds the UI appears broken to the user).
+Sometimes you need a task to take *at least* a certain amount of time. (For example,
+you want to show a progress spinner, but if it shows for less than 0.3 seconds, the UI
+appears broken to the user.)
 
 ```swift
 let waitAtLeast = after(seconds: 0.3)
@@ -229,14 +231,14 @@ firstly {
 }
 ```
 
-The above works because we create the delay before we do work in `foo()`, thus
-it will have either already timed-out or we wait whatever amount of the 0.3
-seconds remains before the chain continues.
+The code above works because we create the delay *before* we do work in `foo()`. By the 
+time we get to waiting on that promise, either it will have already timed out or we will wait
+for whatever remains of the 0.3 seconds before continuing the chain.
 
 
 ## Cancellation
 
-Promises don’t have a `cancel` function, but they do support cancellation via a
+Promises don’t have a `cancel` function, but they do support cancellation through a
 special error type that conforms to the `CancellableError` protocol.
 
 ```swift
@@ -261,13 +263,13 @@ func foo() -> (Promise<Void>, cancel: () -> Void) {
 }
 ```
 
-> Promises don’t have a cancel function because you don’t want code outside of
-> your control to be able to cancel your operations *unless* you explicitly want
-> that. In cases where you want it, then it varies how it should work depending
-> on how the underlying task supports cancellation. Thus we have provided
-> primitives but not concrete API.
+Promises don’t have a `cancel` function because you don’t want code outside of
+your control to be able to cancel your operations--*unless*, of course, you explicitly
+want to enable that behavior. In cases where you do want cancellation, the exact way 
+that it should work will vary depending on how the underlying task supports cancellation.
+PromiseKit provides cancellation primitives but no concrete API.
 
-Cancelled chains do not call a `catch` handler by default. However you can
+Cancelled chains do not call `catch` handlers by default. However you can
 intercept cancellation if you like:
 
 ```swift
@@ -278,14 +280,14 @@ foo.then {
 }
 ```
 
-**Important**, canceling the chain is *not* the same as canceling the underlying
-asynchronous task. Promises are a wrapper around asynchronicity but they have no
-control over the underlying tasks. If you need to cancel the underlying task you
+**Important**: Canceling a promise chain is *not* the same as canceling the underlying
+asynchronous task. Promises are wrappers around asynchronicity, but they have no
+control over the underlying tasks. If you need to cancel an underlying task, you
 need to cancel the underlying task!
 
 > The library [CancellablePromiseKit](https://github.com/johannesd/CancellablePromiseKit) extends the concept of Promises to fully cover cancellable tasks.
 
-## Retry / Polling
+## Retry / polling
 
 ```swift
 func attempt<T>(maximumRetryCount: Int = 3, delayBeforeRetry: DispatchTimeInterval = .seconds(2), _ body: @escaping () -> Promise<T>) -> Promise<T> {
@@ -309,14 +311,14 @@ attempt(maximumRetryCount: 3) {
 }
 ```
 
-Probably you should supplement the above so that you only re-attempt for
+In most cases, you should probably supplement the code above so that it re-attempts only for
 specific error conditions.
 
 
-## Wrapping Delegate Systems
+## Wrapping delegate systems
 
-Be careful with Promises and delegate systems as they are not always suited.
-Promises complete *once* where most delegate systems call their callbacks many
+Be careful with Promises and delegate systems, as they are not always compatible.
+Promises complete *once*, whereas most delegate systems may notify their delegate many
 times. This is why, for example, there is no PromiseKit extension for a
 `UIButton`.
 
@@ -364,13 +366,13 @@ CLLocationManager.promise().then { locations in
 }
 ```
 
-> Please note, we provide this promise with our CoreLocation extensions at
+> Please note: we provide this promise with our CoreLocation extensions at
 > https://github.com/PromiseKit/CoreLocation
 
 
 ## Recovery
 
-Sometimes you don’t want an error to cascade, instead you have a default value:
+Sometimes you don’t want an error to cascade. Instead, you want to supply a default result:
 
 ```swift
 CLLocationManager.requestLocation().recover { error -> Promise<CLLocation> in
@@ -383,10 +385,10 @@ CLLocationManager.requestLocation().recover { error -> Promise<CLLocation> in
 }
 ```
 
-Be careful not to ignore all errors; recover only those errors that make sense.
+Be careful not to ignore all errors, though! Recover only those errors that make sense to recover.
 
 
-## Promises for modal view-controllers
+## Promises for modal view controllers
 
 ```swift
 class ViewController: UIViewController {
@@ -414,10 +416,10 @@ ViewController().show(in: self).done {
 ```
 
 This is the best approach we have found, which is a pity as it requires the
-presentee to control the presentation and the presentee to be dismiss itself
+presentee to control the presentation and requires the presentee to dismiss itself
 explicitly.
 
-Nothing seemingly can beat Storyboard segues for decoupling an app's router.
+Nothing seems to beat storyboard segues for decoupling an app's controllers.
 
 
 ## Saving previous results
@@ -435,7 +437,7 @@ login().then { username in
 
 What if you want access to both `username` and `image` in your `done`?
 
-The most obvious way is with nesting:
+The most obvious way is to use nesting:
 
 ```swift
 login().then { username in
@@ -447,7 +449,7 @@ login().then { username in
 }
 ```
 
-However this nesting reduces the chain’s clarity; instead we could use Swift
+However, such nesting reduces the clarity of the chain. Instead, we could use Swift
 tuples:
 
 ```swift
@@ -458,10 +460,10 @@ login().then { username in
 }
 ```
 
-The above simply maps `Promise<String>` into `Promise<(UIImage, String)>`.
+The code above simply maps `Promise<String>` into `Promise<(UIImage, String)>`.
 
 
-## Waiting on multiple promises whatever their result
+## Waiting on multiple promises, whatever their result
 
 Use `when(resolved:)`:
 
@@ -473,6 +475,6 @@ when(resolved: a, b).done { (results: [Result<T>]) in
 // ^^ cannot call `catch` as `when(resolved:)` returns a `Guarantee`
 ```
 
-Generally you don't want this, people ask for it a lot, but usually they
-actually just want to use `recover` on one of the promises. Usually you don't
-want to ignore errors. Errors happen, they should be handled.
+Generally, you don't want this! People ask for it a lot, but usually because
+they are trying to ignore errors. What they really need is to use `recover` on one of the
+promises. Errors happen, so they should be handled; you usually don't want to ignore them.

--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -2,12 +2,12 @@
 
 ## Why should I use PromiseKit over X-Promises-Foo?
 
-* PromiseKit has a heavy focus on **developer-experience**. You’re a developer, do you care about your experience? Yes? Then pick PromiseKit.
+* PromiseKit has a heavy focus on **developer experience**. You’re a developer; do you care about your experience? Yes? Then pick PromiseKit.
 * Do you care about having any bugs you find fixed? Then pick PromiseKit.
 * Do you care about having your input heard and reacted to in a fast fashion? Then pick PromiseKit.
 * Do you want a library that has been maintained continuously and passionately for 6 years? Then pick PromiseKit.
 * Do you want a library that the community has chosen to be their №1 Promises/Futures library? Then pick PromiseKit.
-* Do you want to be able to use Promises with Apple’s SDKs rather than have to do all the work of writing the Promise implementations yourself? Then pick PromiseKit.
+* Do you want to be able to use Promises with Apple’s SDKs rather than having to do all the work of writing the Promise implementations yourself? Then pick PromiseKit.
 * Do you want to be able to use Promises with Swift 3.x, Swift 4.x, ObjC, iOS, tvOS, watchOS, macOS, Android & Linux? Then pick PromiseKit.
 * PromiseKit verifies its correctness by testing against the entire [Promises/A+ test suite](https://github.com/promises-aplus/promises-tests).
 
@@ -24,7 +24,7 @@ use `weak self` (and check for `self == nil`) to prevent any such side effects.
 should be protected against are in fact *not* side effects.
 
 Side effects include changes to global application state. They *do not* include
-changing the view of a viewController. So, protect against setting UserDefaults or
+changing the display state of a viewController. So, protect against setting UserDefaults or
 modifying the application database, and don't bother protecting against changing
 the text in a `UILabel`.
 
@@ -33,9 +33,9 @@ has some good discussion on this topic.
 
 ## Do I need to retain my promises?
 
-No, every promise handler retains its promise until the handler is executed. Once
-all handlers are executed the promise is deallocated. So you only need to retain
-the promise if you need to reference its final value after its chain has completed.
+No. Every promise handler retains its promise until the handler is executed. Once
+all handlers have been executed, the promise is deallocated. So you only need to retain
+the promise if you need to refer to its final value after its chain has completed.
 
 ## Where should I put my `catch`?
 
@@ -119,8 +119,8 @@ that hobby-project implementations don’t consider.
 
 ## Why is debugging hard?
 
-Because promises always execute via `dispatch`, the backtraces you get have less
-information than is often required to trace the path of execution.
+Because promises always execute via dispatch, the backtrace you see at the point of 
+an error has less information than is usually required to trace the path of execution.
 
 One solution is to turn off dispatch during debugging:
 
@@ -133,7 +133,7 @@ PMKSetDefaultDispatchQueue(zalgo)
 ```
 
 Don’t leave this on. In normal use, we always dispatch to avoid you accidentally writing
-a common bug pattern: http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony
+a common bug pattern. See [this blog post](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).
 
 ## Where is `all()`?
 
@@ -166,9 +166,53 @@ you typically won't have to worry about this.
 
 Yes. We have tests that prove this.
 
-## How do PromiseKit and RxSwift differ?
+## How do PromiseKit and RxSwift/ReactiveSwift differ?
 
-https://github.com/mxcl/PromiseKit/issues/484
+PromiseKit is a lot simpler.
+
+The top-level difference between PromiseKit and RxSwift is that RxSwift `Observable`s (roughly 
+analogous to PromiseKit `Promise`s) do not necessarily return a single result: they may emit
+zero, one, or an infinite stream of values. This small conceptual change ramifies into an API
+that's both surprisingly powerful and surprisingly complex.
+
+RxSwift requires commitment to a paradigm shift in how you program: it proposes that you
+restructure your code as a matrix of interacting value pipelines. When applied properly
+to a suitable problem, RxSwift can yield great benefits in robustness and simplicity.
+But not all applications are suitable for RxSwift. 
+
+By contrast, PromiseKit selectively applies the best parts of reactive programming
+to the hardest part of pure Swift development, the management of asynchrony. It's a broadly 
+applicable tool: most asynchronous code can be clarified, simplified, and made more robust
+just by converting it to use promises. (And the conversion process is easy.)
+
+Promises make for code that is clear to most developers. RxSwift, perhaps not: take a look at this 
+[signup panel](https://github.com/ReactiveX/RxSwift/tree/master/RxExample/RxExample/Examples/GitHubSignup)
+implemented in RxSwift and see what you think. (Note that this is one of RxSwift's own examples.)
+
+Even where PromiseKit and RxSwift are broadly similar, there are many differences in implementation:
+
+* RxSwift has a separate API for chain-terminating elements ("subscribers") versus interior
+elements. In PromiseKit, all elements of a chain use roughly the same code pattern.
+
+* The RxSwift API to define an interior element of a chain (an "operator") is hair-raisingly complex.
+So, RxSwift tries hard to supply every operator you might ever want to use right off the shelf. There are
+hundreds. PromiseKit supplies a few utilities to help with specific scenarios, but because it's trivial
+to write your own chain elements, there's no need for all this extra code in the library.
+
+* PromiseKit dispatches the execution of every block. RxSwift might or might not. Moreover, the 
+current dispatching state is an attribute of the chain, not the specific block, as it is in PromiseKit.
+The RxSwift system is more powerful but more complex. PromiseKit is simple, predictable, and safe.
+
+* In PromiseKit, both sides of a branched chain refer back to their shared common ancestors. In RxSwift, 
+branching normally creates a duplicate parallel chain that reruns the code at the head of the chain.
+Except when it doesn't. The rules for determining what will actually happen are complex, and given
+a chain created by another chunk of code, you can't really tell what the behavior will be.
+
+* Because RxSwift chains don't necessarily terminate on their own, RxSwift needs you to take on some
+explicit garbage collection duties to ensure that pipelines that are no longer needed are properly
+deallocated. All promises yield a single value, terminate, and then automatically deallocate themselves.
+
+You can find some additional discussion in [this ticket](https://github.com/mxcl/PromiseKit/issues/484).
 
 ## Why can’t I return from a catch like I can in Javascript?
 
@@ -199,7 +243,7 @@ func foo() -> Promise<Any>
 }
 ```
 
-Who chooses when this promise starts? The answer is: Alamofire does and in this
+Who chooses when this promise starts? The answer is: Alamofire does, and in this
 case, it “starts” immediately when `foo()` is called.
 
 ## What is a good way to use Firebase with PromiseKit
@@ -227,8 +271,8 @@ foo.observe(.value) { snapshot in
 ## I need my `then` to fire multiple times
 
 Then we’re afraid you cannot use PromiseKit for that event. Promises only
-resolve *once*. This is the fundamental nature of promises and is considered a
-feature since it gives you guarantees about the flow of your chains.
+resolve *once*. This is the fundamental nature of promises and it is considered a
+feature because it gives you guarantees about the flow of your chains.
 
 
 ## How do I change the default queues that handlers run on?

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -1,7 +1,6 @@
 # Xcode 8.3, 9.x or 10.x / Swift 3 or 4
 
-We recommend Carthage over CocoaPods, but both are supported installation
-methods.
+We recommend Carthage over CocoaPods, but both installation methods are supported.
 
 ## CocoaPods
 
@@ -10,8 +9,8 @@ use_frameworks!
 pod "PromiseKit", "~> 6.0"
 ```
 
-Since CocoaPods 1.0 you will (probably) need to add the `pod` line to a `target`,
-eg:
+After CocoaPods 1.0, you will (probably) need to add the `pod` line to a `target`,
+e.g.:
 
 ```ruby
 use_frameworks!
@@ -71,7 +70,7 @@ We also maintain a series of branches to aid migration for PromiseKit 2:
 |  7.1  |  2.1  | 2          | [swift-2.0-minimal-changes] | ![ci-20]  |
 |  7.0  |  2.0  | 2          | [swift-2.0-minimal-changes] | ![ci-20]  |
 
-We do **not** usually backport fixes to these branches, but pull-requests are welcome.
+We do **not** usually backport fixes to these branches, but pull requests are welcome.
 
 
 ## Xcode 8 / Swift 2.3 or Xcode 7
@@ -102,27 +101,27 @@ github "mxcl/PromiseKit" ~> 3.5
 [swift-2.0-minimal-changes]: https://github.com/mxcl/PromiseKit/tree/swift-2.0-minimal-changes
 
 
-# Using Git Submodules for PromiseKit’s Extensions
+# Using Git submodules for PromiseKit’s extensions
 
-> Please note, this is a more advanced technique
+> *Note*: This is a more advanced technique.
 
-If you use CocoaPods and a few PromiseKit extensions then importing PromiseKit
-causes that module to import all the extension frameworks. Thus if you have an
-app and a few app-extensions (eg. iOS app, iOS watch extension, iOS Today
+If you use CocoaPods and a few PromiseKit extensions, then importing PromiseKit
+causes that module to import all the extension frameworks. Thus, if you have an
+app and a few app extensions (e.g., iOS app, iOS watch extension, iOS Today
 extension) then all your final products that use PromiseKit will have forced
 dependencies on all the Apple frameworks that PromiseKit provides extensions
 for.
 
-This isn’t that bad, but every framework that loads is overhead and startup
-time.
+This isn’t that bad, but every framework that loads entails overhead and 
+lengthens startup time.
 
-It’s better and worse with Carthage since we build individual micro-frameworks
-for each PromiseKit-extension, so at least all your final products only link
-against the Apple frameworks that they actually need. However, Apple have
-advised that apps only link against “about 12” frameworks for performance
-reasons, so for Carthage, we are worse off for this metric.
+It’s both better and worse with Carthage. We build individual micro-frameworks
+for each PromiseKit extension, so your final products link
+against only the Apple frameworks that they actually need. However, Apple has
+advised that apps link only against “about 12” frameworks for performance
+reasons. So with Carthage, we are worse off on this metric.
 
-The solution is to instead only import CorePromise:
+The solution is to instead import only CorePromise:
 
 ```ruby
 # CocoaPods
@@ -142,7 +141,7 @@ git submodule add https://github.com/PromiseKit/UIKit Submodules/PMKUIKit
 
 Then in Xcode you can add these sources to your targets on a per-target basis.
 
-Then when you `pod update`, ensure you also update your submodules:
+Then when you `pod update`, ensure that you also update your submodules:
 
     pod update && git submodule update --recursive --remote
 

--- a/Documentation/ObjectiveC.md
+++ b/Documentation/ObjectiveC.md
@@ -10,13 +10,13 @@ Each is designed to be an appropriate promise implementation for the strong poin
 * `Promise<T>` is strict, defined and precise.
 * `AnyPromise` is loose and dynamic.
 
-Unlike most libraries we have extensive bridging support, you can use PromiseKit
+Unlike most libraries, we have extensive bridging support, you can use PromiseKit
 in mixed projects with mixed language targets and mixed language libraries.
 
 
 # Using PromiseKit with Objective-C
 
-`AnyPromise` is our promise class for Objective-C. It behaves almost identically to `Promise<T>` (our Swift promise class).
+`AnyPromise` is our promise class for Objective-C. It behaves almost identically to `Promise<T>`, our Swift promise class.
 
 ```objc
 myPromise.then(^(NSString *bar){
@@ -50,14 +50,14 @@ myPromise.then(^{
 });
 ```
 #### :warning: Caution:
-ARC in Objective-C unlike Objective-C++ is not exception safe by default.
-So, throwing an error will result in keeping a strong reference to the closure containing the throw statement.
-This will consequently result in memory leaks if you're not careful.
-````
-Note:
-Only having a strong reference to the closure would result in memory leaks.
-In our case PromisKit automatically keeps a strong reference to the closure until it's released.
-````
+ARC in Objective-C, unlike in Objective-C++, is not exception-safe by default.
+So, throwing an error will result in keeping a strong reference to the closure 
+that contains the throw statement.
+This pattern will consequently result in memory leaks if you're not careful.
+
+> *Note:* Only having a strong reference to the closure would result in memory leaks.
+> In our case, PromisKit automatically keeps a strong reference to the closure until it's released.
+
 __Workarounds:__
 1. Return a Promise with value NSError\
 Instead of throwing a normal error, you can return a Promise with value NSError instead.
@@ -109,7 +109,7 @@ We do runtime inspection of the block you pass to achieve this magic.
 
 Another important distinction is that the equivalent function to Swift’s `recover` is combined with `AnyPromise`’s `catch`. This is typical to other “dynamic” promise implementations and thus achieves our goal that `AnyPromise` is loose and dynamic while `Promise<T>` is strict and specific.
 
-A sometimes unexpected consequence of this is that returning nothing from a `catch` *resolves* the returned promise:
+A sometimes unexpected consequence of this fact is that returning nothing from a `catch` *resolves* the returned promise:
 
 ```objc
 myPromise.catch(^{
@@ -121,10 +121,10 @@ myPromise.catch(^{
 
 ---
 
-Another important distinction is that the `value` property returns even if the promise is rejected, in that case it returns the `NSError` object with which the promise was rejected.
+Another important distinction is that the `value` property returns even if the promise is rejected; in that case, it returns the `NSError` object with which the promise was rejected.
 
 
-# Bridging Between Objective-C & Swift
+# Bridging between Objective-C & Swift
 
 Let’s say you have:
 
@@ -134,9 +134,8 @@ Let’s say you have:
 @end
 ```
 
-Ensure this interface is included in your bridging header.
-
-You can now use this in your Swift code:
+Ensure that this interface is included in your bridging header. You can now use the 
+following pattern in your Swift code:
 
 ```swift
 let foo = Foo()
@@ -159,9 +158,9 @@ Let’s say you have:
 @objc class Bar: NSObject { /*…*/ }
 ```
 
-Ensure that your project is generating a `…-Swift.h` header so your Objective-C can see your Swift code.
+Ensure that your project is generating a `…-Swift.h` header so that Objective-C can see your Swift code.
 
-If you built this and opened the `…-Swift.h` header you would only see this:
+If you built this project and opened the `…-Swift.h` header, you would only see this:
 
 ```objc
 @interface Foo
@@ -171,7 +170,7 @@ If you built this and opened the `…-Swift.h` header you would only see this:
 @end
 ```
 
-This is because Objective-C cannot import Swift objects that are generic. Thus we need to write some stubs:
+That's because Objective-C cannot import Swift objects that are generic. So we need to write some stubs:
 
 ```swift
 @objc class Foo: NSObject {
@@ -184,7 +183,7 @@ This is because Objective-C cannot import Swift objects that are generic. Thus w
 }
 ```
 
-If we built this and opened our generated header we would now see:
+If we built this and opened our generated header, we would now see:
 
 ```objc
 @interface Foo
@@ -198,5 +197,5 @@ If we built this and opened our generated header we would now see:
 
 Perfect.
 
-Note that AnyPromise can only bridge objects that conform to `AnyObject` or derive `NSObject`. This is a limitation of Objective-C.
+Note that AnyPromise can only bridge objects that conform to `AnyObject` or derive from `NSObject`. This is a limitation of Objective-C.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 Promises simplify asynchronous programming, freeing you up to focus on the more
-important things. They are easy to learn, easy to master and result in clearer,
+important things. They are easy to learn, easy to master, and result in clearer,
 more readable code. Your co-workers will thank you.
 
 ```swift
@@ -27,8 +27,8 @@ firstly {
 ```
 
 PromiseKit is a thoughtful and complete implementation of promises for any
-platform with a `swiftc`, it has *excellent* Objective-C bridging and
-*delightful* specializations for iOS, macOS, tvOS and watchOS. It is a top-100
+platform that has a `swiftc`. It has *excellent* Objective-C bridging and
+*delightful* specializations for iOS, macOS, tvOS, and watchOS. It is a top-100
 pod used in many of the most popular apps in the world.
 
 [![codecov](https://codecov.io/gh/mxcl/PromiseKit/branch/master/graph/badge.svg)](https://codecov.io/gh/mxcl/PromiseKit)
@@ -49,13 +49,13 @@ target "Change Me!" do
 end
 ```
 
-PromiseKit 6, 5 and 4 support Xcode 8.3, 9.x and 10.0; Swift 3.1,
-3.2, 3.3, 4.0, 4.1 and 4.2 ; iOS, macOS, tvOS, watchOS, Linux and Android; CocoaPods,
-Carthage and SwiftPM; ([CI Matrix](https://travis-ci.org/mxcl/PromiseKit)).
+PromiseKit 6, 5, and 4 support Xcode 8.3, 9.x, and 10.0; Swift 3.1,
+3.2, 3.3, 4.0, 4.1, and 4.2 ; iOS, macOS, tvOS, watchOS, Linux, and Android; CocoaPods,
+Carthage, and SwiftPM; ([CI Matrix](https://travis-ci.org/mxcl/PromiseKit)).
 
 For Carthage, SwiftPM, etc., or for instructions when using older Swifts or
-Xcodes see our [Installation Guide](Documentation/Installation.md). Please note
-that we sincerely recommend [Carthage](https://github.com/Carthage/Carthage).
+Xcodes, see our [Installation Guide](Documentation/Installation.md). We 
+recommend [Carthage](https://github.com/Carthage/Carthage).
 
 # Documentation
 
@@ -66,17 +66,17 @@ that we sincerely recommend [Carthage](https://github.com/Carthage/Carthage).
 * Manual
   * [Installation Guide](Documentation/Installation.md)
   * [Objective-C Guide](Documentation/ObjectiveC.md)
-  * [Troubleshooting](Documentation/Troubleshooting.md) (eg. solutions to common compile errors)
+  * [Troubleshooting](Documentation/Troubleshooting.md) (e.g., solutions to common compile errors)
   * [Appendix](Documentation/Appendix.md)
 * [API Reference](https://promisekit.org/reference/)
 
 # Extensions
 
-Promises are only as useful as the asynchronous tasks they represent, thus we
+Promises are only as useful as the asynchronous tasks they represent. Thus, we
 have converted (almost) all of Apple’s APIs to promises. The default CocoaPod
 provides Promises and the extensions for Foundation and UIKit. The other
 extensions are available by specifying additional subspecs in your `Podfile`,
-eg:
+e.g.:
 
 ```ruby
 pod "PromiseKit/MapKit"          # MKDirections().calculate().then { /*…*/ }
@@ -93,43 +93,12 @@ Then don’t have them:
 pod "PromiseKit/CorePromise", "~> 6.0"
 ```
 
-> *Note* Carthage installations come with no extensions by default.
+> *Note:* Carthage installations come with no extensions by default.
 
-## Choose Your Networking Library
+## Choose your networking library
 
-Promise chains are commonly started with networking, thus we offer [Alamofire]:
-
-```swift
-// pod 'PromiseKit/Alamofire'  # https://github.com/PromiseKit/Alamofire-
-
-firstly {
-    Alamofire
-        .request("http://example.com", method: .post, parameters: params)
-        .responseDecodable(Foo.self)
-}.done { foo in
-    //…
-}.catch { error in
-    //…
-}
-```
-
-[OMGHTTPURLRQ]:
-
-```swift
-// pod 'PromiseKit/OMGHTTPURLRQ'  # https://github.com/PromiseKit/OMGHTTPURLRQ
-
-firstly {
-    URLSession.shared.POST("http://example.com", JSON: params)
-}.map {
-    try JSONDecoder().decoder(Foo.self, with: $0.data)
-}.done { foo in
-    //…
-}.catch { error in
-    //…
-}
-```
-
-And (of course) plain `URLSession`:
+Promise chains commonly start with a network operation. Thus, we offer
+extensions for `URLSession`:
 
 ```swift
 // pod 'PromiseKit/Foundation'  # https://github.com/PromiseKit/Foundation
@@ -154,22 +123,54 @@ func makeUrlRequest() throws -> URLRequest {
 }
 ```
 
+[Alamofire]:
+
+```swift
+// pod 'PromiseKit/Alamofire'  # https://github.com/PromiseKit/Alamofire-
+
+firstly {
+    Alamofire
+        .request("http://example.com", method: .post, parameters: params)
+        .responseDecodable(Foo.self)
+}.done { foo in
+    //…
+}.catch { error in
+    //…
+}
+```
+
+And [OMGHTTPURLRQ]:
+
+```swift
+// pod 'PromiseKit/OMGHTTPURLRQ'  # https://github.com/PromiseKit/OMGHTTPURLRQ
+
+firstly {
+    URLSession.shared.POST("http://example.com", JSON: params)
+}.map {
+    try JSONDecoder().decoder(Foo.self, with: $0.data)
+}.done { foo in
+    //…
+}.catch { error in
+    //…
+}
+```
+
 Nowadays, considering that:
 
 * We almost always POST JSON
 * We now have `JSONDecoder`
 * PromiseKit now has `map` and other functional primitives
 
-We recommend vanilla `URLSession`; use less black-boxes, stick closer to the
+We recommend vanilla `URLSession`. It uses fewer black boxes and sticks closer to the
 metal. Alamofire was essential until the three bulletpoints above became true,
 but nowadays it isn’t really necessary. OMGHTTPURLRQ was developed before JSON
-was the modern standard and thus REST requests were hard, but nowadays you
-rarely network anything but JSON.
+was the modern standard and thus REST requests were hard, but these days you
+rarely need to speak any format but JSON.
 
 # Support
 
-Please check our [Troubleshooting Guide](Documentation/Troubleshooting.md) and
-if after that you still have a question ask at our [Gitter chat channel] or on [our bug tracker].
+Please check our [Troubleshooting Guide](Documentation/Troubleshooting.md), and
+if after that you still have a question, ask at our [Gitter chat channel] or on [our bug tracker].
 
 
 [badge-pod]: https://img.shields.io/cocoapods/v/PromiseKit.svg?label=version


### PR DESCRIPTION
This is mostly just editing for grammar, consistency, and flow. A couple of points will need review, though:

1) I added a couple more sentences about Swift type inference to the Troubleshooting section. This is just general Swift info, nothing really specific to PromiseKit.

2) I edited one of the code examples about `asVoid()` in the Appendix. The original code was:

```
let p1 = foo()
let p2 = bar()
let p3 = baz()
//…
let p10 = fluff()

when(fulfilled: p1, p2, p3, /*…*/, p10).then {
    let value1 = foo().value!  // safe bang since all the promises fulfilled
    // …
    let value10 = fluff().value!
}.catch {
    //…
}
```

It seemed suspicious because a) this is described as an example that shows `asVoid()` being essential, but it does not call `asVoid()`, and b) if `foo()` etc produce promises, then doesn't calling those functions again just produce new, independent promises?  This was my guess at the intended code:

```
let p1 = foo()
let p2 = bar()
let p3 = baz()
//…
let p10 = fluff()

when(fulfilled: p1.asVoid(), p2.asVoid(), /*…*/, p10.asVoid()).then {
    let value1 = p1.value!  // safe bang since all the promises fulfilled
    // …
    let value10 = p10.value!
}.catch {
    //…
}
```

3) I added an in-line answer to the FAQ question about RxSwift. Some of the text draws from the existing trouble ticket, but most is new, although I think it's consistent with the material that is already around. This answer may be too long given the generally brief style of the documentation. Feel free to trim, or I'll do it if you prefer. I do think this is a common query for people new to both libraries.