### PR TITLE
implement guarantee get returns guarantee

### DIFF
--- a/Sources/Guarantee.swift
+++ b/Sources/Guarantee.swift
@@ -76,6 +76,13 @@ public extension Guarantee {
         }
         return rg
     }
+    
+    func get(on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping (T) -> Void) -> Guarantee<T> {
+        return map(on: on, flags: flags) {
+            body($0)
+            return $0
+        }
+    }
 
     func map<U>(on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ body: @escaping(T) -> U) -> Guarantee<U> {
         let rg = Guarantee<U>(.pending)


### PR DESCRIPTION
Closes #889 

With this additional `.get` on a `Guarantee` one is able to write something like this without catch block

```swift
firstly {
    fetchUser() // returns Guarantee<String>
}.get {
    self.user = $0
}.done { user in
    self.label.text = user.name
}
```