### PR TITLE
Update documentation referencing `.allErrorsIncludingCancellation`

### DIFF
--- a/Documentation/CommonPatterns.md
+++ b/Documentation/CommonPatterns.md
@@ -275,7 +275,7 @@ intercept cancellation if you like:
 ```swift
 foo.then {
     //…
-}.catch(policy: .allErrorsIncludingCancellation) {
+}.catch(policy: .allErrors) {
     // cancelled errors are handled *as well*
 }
 ```


### PR DESCRIPTION
Updating references to .allErrorsIncludingCancellation to .allErrors in the documentation.