### PR TITLE
Add async as a Promise class func

### DIFF
--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -102,6 +102,23 @@ public class Promise<T>: Thenable, CatchMixin {
 }
 
 public extension Promise {
+    
+    /**
+     Shorter way to make an async function
+
+     func myAsynFunc() -> Promise<Int> {
+         return .async {
+             let myNumber1 = try self.myPromisedCalulation().wait()
+             let myNumber2 = try self.myOtherLongCalculation().wait()
+     
+             return myNumber1 + myNumber2
+         }
+     }
+     */
+    public class func async(group: DispatchGroup? = nil, qos: DispatchQoS = .default, flags: DispatchWorkItemFlags = [], execute body: @escaping () throws -> T) -> Promise<T> {
+        return DispatchQueue.global(qos: qos.qosClass).async(.promise, group: group, qos: qos, flags: flags, execute: body)
+    }
+    
     /**
      Blocks this thread, so—you know—don’t call this on a serial thread that
      any part of your chain may use. Like the main thread for example.


### PR DESCRIPTION
Just a quicker way to make an async function without having to directly use `DispatchQueue.async(PMKNamespacer)`.

The fun part of this extension is that you can use `.async { }` in the return of a function just like with `.value()`, making the code more readable. 

Example: 
```swift
func qResponse<T>() -> Promise<QResponse<T>> {
        return .async {
            let (data, res) = try self.response().wait()
            var qRes = try JSONDecoder().decode(QResponse<T>.self, from: data)
            qRes.status = (res as? HTTPURLResponse)?.statusCode ?? -1
            return qRes
        }
}
```

Happy to learn if there is a cleaner way I'm not seeing.