### PR TITLE
Fix spacing in the example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ more readable code. Your co-workers will thank you.
 ```swift
 UIApplication.shared.isNetworkActivityIndicatorVisible = true
 
-let fetchImage = URLSession.shared.dataTask(.promise, with: url).compactMap{ UIImage(data: $0.data) }
+let fetchImage = URLSession.shared.dataTask(.promise, with: url).compactMap { UIImage(data: $0.data) }
 let fetchLocation = CLLocationManager.requestLocation().lastValue
 
 firstly {


### PR DESCRIPTION
I noticed there is missing space in the second example line in README.md. If it was anywhere else (not on the front page) I would not be making such a small and silly pull request.