### PR TITLE
[Proposal] Provide for separate handling of specific errors in promise chains.

### DIFF
--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -54,11 +54,11 @@ public extension CatchMixin {
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func catchOnly<Error: Swift.Error>(_ only: Error, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where Error: Equatable {
+    func catchOnly<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where E: Equatable {
         let finalizer = PMKCascadingFinalizer()
         pipe {
             switch $0 {
-            case .rejected(let error as Error) where error == only:
+            case .rejected(let error as E) where error == only:
                 on.async(flags: flags) {
                     body()
                     finalizer.pending.resolver.fulfill(())
@@ -85,11 +85,11 @@ public extension CatchMixin {
      - Parameter execute: The handler to execute if this promise is rejected.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func catchOnly<Error: Swift.Error>(_ only: Error.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) -> Void) -> PMKCascadingFinalizer {
+    func catchOnly<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {
         let finalizer = PMKCascadingFinalizer()
         pipe {
             switch $0 {
-            case .rejected(let error as Error):
+            case .rejected(let error as E):
                 guard policy == .allErrors || !error.isCancelled else {
                     return finalizer.pending.resolver.reject(error)
                 }
@@ -156,7 +156,7 @@ public class PMKCascadingFinalizer {
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    public func catchOnly<Error: Swift.Error>(_ only: Error, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where Error: Equatable {
+    public func catchOnly<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where E: Equatable {
         return pending.promise.catchOnly(only, on: on, flags: flags) {
             body()
         }
@@ -175,7 +175,7 @@ public class PMKCascadingFinalizer {
      - Parameter execute: The handler to execute if this promise is rejected.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    public func catchOnly<Error: Swift.Error>(_ only: Error.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) -> Void) -> PMKCascadingFinalizer {
+    public func catchOnly<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {
         return pending.promise.catchOnly(only, on: on, flags: flags, policy: policy) {
             body($0)
         }

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -54,7 +54,7 @@ public extension CatchMixin {
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func catchOnly<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where E: Equatable {
+    func `catch`<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where E: Equatable {
         let finalizer = PMKCascadingFinalizer()
         pipe {
             switch $0 {
@@ -85,7 +85,7 @@ public extension CatchMixin {
      - Parameter execute: The handler to execute if this promise is rejected with the provided error type.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func catchOnly<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {
+    func `catch`<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {
         let finalizer = PMKCascadingFinalizer()
         pipe {
             switch $0 {
@@ -156,8 +156,8 @@ public class PMKCascadingFinalizer {
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    public func catchOnly<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where E: Equatable {
-        return pending.promise.catchOnly(only, on: on, flags: flags) {
+    public func `catch`<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where E: Equatable {
+        return pending.promise.catch(only, on: on, flags: flags) {
             body()
         }
     }
@@ -175,8 +175,8 @@ public class PMKCascadingFinalizer {
      - Parameter execute: The handler to execute if this promise is rejected with the provided error type.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    public func catchOnly<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {
-        return pending.promise.catchOnly(only, on: on, flags: flags, policy: policy) {
+    public func `catch`<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {
+        return pending.promise.catch(only, on: on, flags: flags, policy: policy) {
             body($0)
         }
     }
@@ -234,7 +234,7 @@ public extension CatchMixin {
 
          firstly {
              CLLocationManager.requestLocation()
-         }.recoverOnly(CLError.unknownLocation) {
+         }.recover(CLError.unknownLocation) {
              return .value(CLLocation.chicago)
          }
 
@@ -244,7 +244,7 @@ public extension CatchMixin {
      - Note: Since this method recovers only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func recoverOnly<U: Thenable, E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> U) -> Promise<T> where U.T == T, E: Equatable {
+    func recover<U: Thenable, E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> U) -> Promise<T> where U.T == T, E: Equatable {
         let rp = Promise<U.T>(.pending)
         pipe {
             switch $0 {
@@ -275,7 +275,7 @@ public extension CatchMixin {
 
          firstly {
              API.fetchData()
-         }.recoverOnly(FetchError.self) { error in
+         }.recover(FetchError.self) { error in
              guard case .missingImage(let partialData) = error else { throw error }
              //…
              return .value(dataWithDefaultImage)
@@ -286,7 +286,7 @@ public extension CatchMixin {
      - Parameter body: The handler to execute if this promise is rejected with the provided error type.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func recoverOnly<U: Thenable, E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) throws -> U) -> Promise<T> where U.T == T {
+    func recover<U: Thenable, E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) throws -> U) -> Promise<T> where U.T == T {
         let rp = Promise<U.T>(.pending)
         pipe {
             switch $0 {
@@ -482,7 +482,7 @@ public extension CatchMixin where T == Void {
      - Note: Since this method recovers only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func recoverOnly<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> Promise<Void> where E: Equatable {
+    func recover<E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> Promise<Void> where E: Equatable {
         let rp = Promise<Void>(.pending)
         pipe {
             switch $0 {
@@ -511,7 +511,7 @@ public extension CatchMixin where T == Void {
      - Parameter body: The handler to execute if this promise is rejected with the provided error type.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func recoverOnly<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) throws -> Void) -> Promise<Void> {
+    func recover<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) throws -> Void) -> Promise<Void> {
         let rp = Promise<Void>(.pending)
         pipe {
             switch $0 {

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -227,6 +227,93 @@ public extension CatchMixin {
     }
 
     /**
+     The provided closure executes when this promise rejects with the specific error passed in.
+
+     Unlike `catch`, `recover` continues the chain.
+     Use `recover` in circumstances where recovering the chain from certain errors is a possibility. For example:
+
+         firstly {
+             CLLocationManager.requestLocation()
+         }.recoverOnly(CLError.unknownLocation) {
+             return .value(CLLocation.chicago)
+         }
+
+     - Parameter only: The specific error to be recovered.
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The handler to execute if this promise is rejected with the provided error.
+     - Note: Since this method recovers only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
+     */
+    func recoverOnly<U: Thenable, E: Swift.Error>(_ only: E, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> U) -> Promise<T> where U.T == T, E: Equatable {
+        let rp = Promise<U.T>(.pending)
+        pipe {
+            switch $0 {
+            case .fulfilled(let value):
+                rp.box.seal(.fulfilled(value))
+            case .rejected(let error as E) where error == only:
+                on.async(flags: flags) {
+                    do {
+                        let rv = body()
+                        guard rv !== rp else { throw PMKError.returnedSelf }
+                        rv.pipe(to: rp.box.seal)
+                    } catch {
+                        rp.box.seal(.rejected(error))
+                    }
+                }
+            case .rejected(let error):
+                rp.box.seal(.rejected(error))
+            }
+        }
+        return rp
+    }
+
+    /**
+     The provided closure executes when this promise rejects with an error of the type passed in.
+
+     Unlike `catch`, `recover` continues the chain.
+     Use `recover` in circumstances where recovering the chain from certain errors is a possibility. For example:
+
+         firstly {
+             API.fetchData()
+         }.recoverOnly(FetchError.self) { error in
+             guard case .missingImage(let partialData) = error else { throw error }
+             //…
+             return .value(dataWithDefaultImage)
+         }
+
+     - Parameter only: The error type to be recovered.
+     - Parameter on: The queue to which the provided closure dispatches.
+     - Parameter body: The handler to execute if this promise is rejected with the provided error type.
+     - SeeAlso: [Cancellation](http://promisekit.org/docs/)
+     */
+    func recoverOnly<U: Thenable, E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.map, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) throws -> U) -> Promise<T> where U.T == T {
+        let rp = Promise<U.T>(.pending)
+        pipe {
+            switch $0 {
+            case .fulfilled(let value):
+                rp.box.seal(.fulfilled(value))
+            case .rejected(let error as E):
+                if policy == .allErrors || !error.isCancelled {
+                    on.async(flags: flags) {
+                        do {
+                            let rv = try body(error)
+                            guard rv !== rp else { throw PMKError.returnedSelf }
+                            rv.pipe(to: rp.box.seal)
+                        } catch {
+                            rp.box.seal(.rejected(error))
+                        }
+                    }
+                } else {
+                    rp.box.seal(.rejected(error))
+                }
+            case .rejected(let error):
+                rp.box.seal(.rejected(error))
+            }
+        }
+        return rp
+    }
+
+    /**
      The provided closure executes when this promise rejects.
      This variant of `recover` requires the handler to return a Guarantee, thus it returns a Guarantee itself and your closure cannot `throw`.
      - Note it is logically impossible for this to take a `catchPolicy`, thus `allErrors` are handled.

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -41,7 +41,7 @@ public extension CatchMixin {
     }
 
     /**
-     The provided closure executes when this promise rejects with the specific error passed in. A final `catch` is still required at the end of your chain.
+     The provided closure executes when this promise rejects with the specific error passed in. A final `catch` is still required at the end of the chain.
 
      Rejecting a promise cascades: rejecting all subsequent promises (unless
      recover is invoked) thus you will typically place your catch at the end
@@ -50,7 +50,7 @@ public extension CatchMixin {
 
      - Parameter only: The specific error to be caught and handled.
      - Parameter on: The queue to which the provided closure dispatches.
-     - Parameter execute: The handler to execute if this promise is rejected.
+     - Parameter execute: The handler to execute if this promise is rejected with the provided error.
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
@@ -73,7 +73,7 @@ public extension CatchMixin {
     }
 
     /**
-     The provided closure executes when this promise rejects with an error of the type passed in. A final `catch` is still required at the end of your chain.
+     The provided closure executes when this promise rejects with an error of the type passed in. A final `catch` is still required at the end of the chain.
 
      Rejecting a promise cascades: rejecting all subsequent promises (unless
      recover is invoked) thus you will typically place your catch at the end
@@ -82,7 +82,7 @@ public extension CatchMixin {
 
      - Parameter only: The error type to be caught and handled.
      - Parameter on: The queue to which the provided closure dispatches.
-     - Parameter execute: The handler to execute if this promise is rejected.
+     - Parameter execute: The handler to execute if this promise is rejected with the provided error type.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
     func catchOnly<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {
@@ -143,7 +143,7 @@ public class PMKCascadingFinalizer {
     }
 
     /**
-     The provided closure executes when this promise rejects with the specific error passed in. A final `catch` is still required at the end of your chain.
+     The provided closure executes when this promise rejects with the specific error passed in. A final `catch` is still required at the end of the chain.
 
      Rejecting a promise cascades: rejecting all subsequent promises (unless
      recover is invoked) thus you will typically place your catch at the end
@@ -152,7 +152,7 @@ public class PMKCascadingFinalizer {
 
      - Parameter only: The specific error to be caught and handled.
      - Parameter on: The queue to which the provided closure dispatches.
-     - Parameter execute: The handler to execute if this promise is rejected.
+     - Parameter execute: The handler to execute if this promise is rejected with the provided error.
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
@@ -163,7 +163,7 @@ public class PMKCascadingFinalizer {
     }
 
     /**
-     The provided closure executes when this promise rejects with an error of the type passed in. A final `catch` is still required at the end of your chain.
+     The provided closure executes when this promise rejects with an error of the type passed in. A final `catch` is still required at the end of the chain.
 
      Rejecting a promise cascades: rejecting all subsequent promises (unless
      recover is invoked) thus you will typically place your catch at the end
@@ -172,7 +172,7 @@ public class PMKCascadingFinalizer {
 
      - Parameter only: The error type to be caught and handled.
      - Parameter on: The queue to which the provided closure dispatches.
-     - Parameter execute: The handler to execute if this promise is rejected.
+     - Parameter execute: The handler to execute if this promise is rejected with the provided error type.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
     public func catchOnly<E: Swift.Error>(_ only: E.Type, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(E) -> Void) -> PMKCascadingFinalizer {

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -474,13 +474,7 @@ public extension CatchMixin where T == Void {
      The provided closure executes when this promise rejects with the specific error passed in.
 
      Unlike `catch`, `recover` continues the chain.
-     Use `recover` in circumstances where recovering the chain from certain errors is a possibility. For example:
-
-     firstly {
-         CLLocationManager.requestLocation()
-     }.recoverOnly(CLError.unknownLocation) {
-         return .value(CLLocation.chicago)
-     }
+     Use `recover` in circumstances where recovering the chain from certain errors is a possibility.
 
      - Parameter only: The specific error to be recovered.
      - Parameter on: The queue to which the provided closure dispatches.
@@ -510,15 +504,7 @@ public extension CatchMixin where T == Void {
      The provided closure executes when this promise rejects with an error of the type passed in.
 
      Unlike `catch`, `recover` continues the chain.
-     Use `recover` in circumstances where recovering the chain from certain errors is a possibility. For example:
-
-     firstly {
-         API.fetchData()
-     }.recoverOnly(FetchError.self) { error in
-         guard case .missingImage(let partialData) = error else { throw error }
-         //…
-         return .value(dataWithDefaultImage)
-     }
+     Use `recover` in circumstances where recovering the chain from certain errors is a possibility.
 
      - Parameter only: The error type to be recovered.
      - Parameter on: The queue to which the provided closure dispatches.

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -54,13 +54,13 @@ public extension CatchMixin {
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    func catchOnly<Error: Swift.Error>(_ only: Error, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping(Error) -> Void) -> PMKCascadingFinalizer where Error: Equatable {
+    func catchOnly<Error: Swift.Error>(_ only: Error, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where Error: Equatable {
         let finalizer = PMKCascadingFinalizer()
         pipe {
             switch $0 {
             case .rejected(let error as Error) where error == only:
                 on.async(flags: flags) {
-                    body(error)
+                    body()
                     finalizer.pending.resolver.fulfill(())
                 }
             case .rejected(let error):
@@ -154,9 +154,9 @@ public class PMKCascadingFinalizer {
      - Note: Since this method handles only specific errors, supplying a `CatchPolicy` is unsupported. You can instead specify e.g. your cancellable error.
      - SeeAlso: [Cancellation](http://promisekit.org/docs/)
      */
-    public func catchOnly<Error: Swift.Error>(_ only: Error, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping(Error) -> Void) -> PMKCascadingFinalizer where Error: Equatable {
+    public func catchOnly<Error: Swift.Error>(_ only: Error, on: DispatchQueue? = conf.Q.return, flags: DispatchWorkItemFlags? = nil, _ body: @escaping() -> Void) -> PMKCascadingFinalizer where Error: Equatable {
         return pending.promise.catchOnly(only, on: on, flags: flags) {
-            body($0)
+            body()
         }
     }
 

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -487,11 +487,11 @@ public extension CatchMixin where T == Void {
         pipe {
             switch $0 {
             case .fulfilled:
-                rp.box.seal(.fulfilled())
+                rp.box.seal(.fulfilled(()))
             case .rejected(let error as E) where error == only:
                 on.async(flags: flags) {
                     body()
-                    rp.box.seal(.fulfilled())
+                    rp.box.seal(.fulfilled(()))
                 }
             case .rejected(let error):
                 rp.box.seal(.rejected(error))
@@ -516,13 +516,12 @@ public extension CatchMixin where T == Void {
         pipe {
             switch $0 {
             case .fulfilled:
-                rp.box.seal(.fulfilled())
+                rp.box.seal(.fulfilled(()))
             case .rejected(let error as E):
                 if policy == .allErrors || !error.isCancelled {
                     on.async(flags: flags) {
                         do {
-                            try body(error)
-                            rp.box.seal(.fulfilled())
+                            rp.box.seal(.fulfilled(try body(error)))
                         } catch {
                             rp.box.seal(.rejected(error))
                         }

--- a/Tests/CorePromise/CatchableTests.swift
+++ b/Tests/CorePromise/CatchableTests.swift
@@ -264,7 +264,7 @@ extension CatchableTests {
 
         Promise.value(1).then { _ -> Promise<Void> in
             throw Error.dummy
-        }.catchOnly(Error.dummy) { _ in
+        }.catchOnly(Error.dummy) {
             x.fulfill()
         }.silenceWarning()
 
@@ -276,10 +276,10 @@ extension CatchableTests {
 
         Promise.value(1).then { _ -> Promise<Void> in
             throw Error.dummy
-        }.catchOnly(Error.dummy) { _ in
+        }.catchOnly(Error.dummy) {
             x.fulfill()
         }.catchOnly(Error.cancelled) {
-            XCTFail("\($0) error was caught")
+            XCTFail()
             x.fulfill()
         }.silenceWarning()
 
@@ -292,9 +292,9 @@ extension CatchableTests {
         Promise.value(1).then { _ -> Promise<Void> in
             throw Error.dummy
         }.catchOnly(Error.cancelled) {
-            XCTFail("\($0) error was caught")
+            XCTFail()
             x.fulfill()
-        }.catchOnly(Error.dummy) { _ in
+        }.catchOnly(Error.dummy) {
             x.fulfill()
         }.silenceWarning()
 
@@ -306,7 +306,7 @@ extension CatchableTests {
 
         Promise.value(1).then { _ -> Promise<Void> in
             throw Error.dummy
-        }.catchOnly(Error.dummy) { _ in
+        }.catchOnly(Error.dummy) {
             x.fulfill()
         }.catch { _ in
             XCTFail()
@@ -321,7 +321,7 @@ extension CatchableTests {
 
         Promise.value(1).then { _ -> Promise<Void> in
             throw Error.dummy
-        }.catchOnly(Error.cancelled) { _ in
+        }.catchOnly(Error.cancelled) {
             XCTFail()
             x.fulfill()
         }.catch { _ in
@@ -351,7 +351,7 @@ extension CatchableTests {
         }.catchOnly(Error.self) { _ in
             x.fulfill()
         }.catchOnly(Error.dummy) {
-            XCTFail("\($0) error was caught")
+            XCTFail()
             x.fulfill()
         }.silenceWarning()
 
@@ -363,10 +363,10 @@ extension CatchableTests {
 
         Promise.value(1).then { _ -> Promise<Void> in
             throw Error.dummy
-        }.catchOnly(Error.dummy) { _ in
+        }.catchOnly(Error.dummy) {
             x.fulfill()
-        }.catchOnly(Error.self) {
-            XCTFail("\($0) error was caught")
+        }.catchOnly(Error.self) { _ in
+            XCTFail()
             x.fulfill()
         }.silenceWarning()
 

--- a/Tests/CorePromise/CatchableTests.swift
+++ b/Tests/CorePromise/CatchableTests.swift
@@ -262,9 +262,7 @@ extension CatchableTests {
     func testCatchOnly() {
         let x = expectation(description: #file + #function)
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
             x.fulfill()
         }.silenceWarning()
 
@@ -274,9 +272,7 @@ extension CatchableTests {
     func testCatchOnly_PatternMatch_1() {
         let x = expectation(description: "Pattern match only Error.dummy")
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
             x.fulfill()
         }.catchOnly(Error.cancelled) {
             XCTFail()
@@ -289,9 +285,7 @@ extension CatchableTests {
     func testCatchOnly_PatternMatch_2() {
         let x = expectation(description: "Pattern match only Error.dummy")
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.cancelled) {
+        Promise<Int>(error: Error.dummy).catchOnly(Error.cancelled) {
             XCTFail()
             x.fulfill()
         }.catchOnly(Error.dummy) {
@@ -304,9 +298,7 @@ extension CatchableTests {
     func testCatchOnly_BaseCatchIsNotCalledAfterCatchOnlyExecutes() {
         let x = expectation(description: #file + #function)
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
             x.fulfill()
         }.catch { _ in
             XCTFail()
@@ -319,9 +311,7 @@ extension CatchableTests {
     func testCatchOnly_BaseCatchIsCalledWhenCatchOnlyDoesNotExecute() {
         let x = expectation(description: #file + #function)
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.cancelled) {
+        Promise<Int>(error: Error.dummy).catchOnly(Error.cancelled) {
             XCTFail()
             x.fulfill()
         }.catch { _ in
@@ -334,9 +324,7 @@ extension CatchableTests {
     func testCatchOnly_Type() {
         let x = expectation(description: #file + #function)
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.self) { _ in
+        Promise<Int>(error: Error.dummy).catchOnly(Error.self) { _ in
             x.fulfill()
         }.silenceWarning()
 
@@ -346,9 +334,7 @@ extension CatchableTests {
     func testCatchOnly_Type_PatternMatch_1() {
         let x = expectation(description: "Pattern match only Error.Type")
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.self) { _ in
+        Promise<Int>(error: Error.dummy).catchOnly(Error.self) { _ in
             x.fulfill()
         }.catchOnly(Error.dummy) {
             XCTFail()
@@ -361,9 +347,7 @@ extension CatchableTests {
     func testCatchOnly_Type_PatternMatch_2() {
         let x = expectation(description: "Pattern match only Error.dummy")
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
             x.fulfill()
         }.catchOnly(Error.self) { _ in
             XCTFail()
@@ -376,9 +360,7 @@ extension CatchableTests {
     func testCatchOnly_Type_BaseCatchIsNotCalledAfterCatchOnlyExecutes() {
         let x = expectation(description: #file + #function)
 
-        Promise.value(1).then { _ -> Promise<Void> in
-            throw Error.dummy
-        }.catchOnly(Error.self) { _ in
+        Promise<Int>(error: Error.dummy).catchOnly(Error.self) { _ in
             x.fulfill()
         }.catch { _ in
             XCTFail()

--- a/Tests/CorePromise/CatchableTests.swift
+++ b/Tests/CorePromise/CatchableTests.swift
@@ -618,6 +618,127 @@ extension CatchableTests {
     }
 }
 
+/// `Promise<Void>.recoverOnly`
+extension CatchableTests {
+    func testRecoverOnly_Object_Void() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Void>(error: Error.dummy).recoverOnly(Error.dummy) {
+            return ()
+        }.done {
+            x.fulfill()
+        }.catch { _ in
+            XCTFail()
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testRecoverOnly_Object_Void_Fufilled() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Void>.value(()).recoverOnly(Error.dummy) {
+            XCTFail()
+            x.fulfill()
+        }.done {
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testRecoverOnly_Object_Void_Ignored() {
+        let x = expectation(description: #file + #function)
+
+        enum Foo: Swift.Error { case bar }
+
+        Promise<Void>(error: Error.dummy).recoverOnly(Foo.bar) {
+            XCTFail()
+            x.fulfill()
+        }.done {
+            XCTFail()
+            x.fulfill()
+        }.catch { _ in
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testRecoverOnly_Type_Void() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Void>(error: Error.dummy).recoverOnly(Error.self) { _ in }.done {
+            x.fulfill()
+        }.catch { _ in
+            XCTFail()
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testRecoverOnly_Type_Void_Fufilled() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Void>.value(()).recoverOnly(Error.self) { _ in
+            XCTFail()
+            x.fulfill()
+        }.done {
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testRecoverOnly_Type_Void_Ignored() {
+        let x = expectation(description: #file + #function)
+
+        enum Foo: Swift.Error { case bar }
+
+        Promise<Void>(error: Error.dummy).recoverOnly(Foo.self) { _ in
+            XCTFail()
+            x.fulfill()
+        }.done {
+            XCTFail()
+            x.fulfill()
+        }.catch { _ in
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testRecoverOnly_Type_Void_Rethrow() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Void>(error: Error.dummy).recoverOnly(Error.self) { _ in
+            throw Error.dummy
+        }.done {
+            XCTFail()
+            x.fulfill()
+        }.catch { _ in
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testRecoverOnly_Type_Void_Cancellation_Ignore() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Void>(error: Error.cancelled).recoverOnly(Error.self) { _ in }.done {
+            XCTFail()
+            x.fulfill()
+        }.catch(policy: .allErrors) { _ in
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+}
+
 private enum Error: CancellableError {
     case dummy
     case cancelled

--- a/Tests/CorePromise/CatchableTests.swift
+++ b/Tests/CorePromise/CatchableTests.swift
@@ -257,12 +257,12 @@ extension CatchableTests {
     }
 }
 
-/// `Promise<T>.catchOnly`
+/// `Promise<T>.catch(_ only:)`
 extension CatchableTests {
     func testCatchOnly() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catch(Error.dummy) {
             x.fulfill()
         }.silenceWarning()
 
@@ -272,9 +272,9 @@ extension CatchableTests {
     func testCatchOnly_PatternMatch_1() {
         let x = expectation(description: "Pattern match only Error.dummy")
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catch(Error.dummy) {
             x.fulfill()
-        }.catchOnly(Error.cancelled) {
+        }.catch(Error.cancelled) {
             XCTFail()
             x.fulfill()
         }.silenceWarning()
@@ -285,10 +285,10 @@ extension CatchableTests {
     func testCatchOnly_PatternMatch_2() {
         let x = expectation(description: "Pattern match only Error.dummy")
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.cancelled) {
+        Promise<Int>(error: Error.dummy).catch(Error.cancelled) {
             XCTFail()
             x.fulfill()
-        }.catchOnly(Error.dummy) {
+        }.catch(Error.dummy) {
             x.fulfill()
         }.silenceWarning()
 
@@ -298,7 +298,7 @@ extension CatchableTests {
     func testCatchOnly_BaseCatchIsNotCalledAfterCatchOnlyExecutes() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catch(Error.dummy) {
             x.fulfill()
         }.catch { _ in
             XCTFail()
@@ -311,7 +311,7 @@ extension CatchableTests {
     func testCatchOnly_BaseCatchIsCalledWhenCatchOnlyDoesNotExecute() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.cancelled) {
+        Promise<Int>(error: Error.dummy).catch(Error.cancelled) {
             XCTFail()
             x.fulfill()
         }.catch { _ in
@@ -324,7 +324,7 @@ extension CatchableTests {
     func testCatchOnly_Type() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.self) { _ in
+        Promise<Int>(error: Error.dummy).catch(Error.self) { _ in
             x.fulfill()
         }.silenceWarning()
 
@@ -336,7 +336,7 @@ extension CatchableTests {
 
         enum Foo: Swift.Error {}
 
-        Promise<Int>(error: Error.dummy).catchOnly(Foo.self) { _ in
+        Promise<Int>(error: Error.dummy).catch(Foo.self) { _ in
             XCTFail()
             x.fulfill()
         }.catch { _ in
@@ -349,9 +349,9 @@ extension CatchableTests {
     func testCatchOnly_Type_PatternMatch_1() {
         let x = expectation(description: "Pattern match only Error.Type")
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.self) { _ in
+        Promise<Int>(error: Error.dummy).catch(Error.self) { _ in
             x.fulfill()
-        }.catchOnly(Error.dummy) {
+        }.catch(Error.dummy) {
             XCTFail()
             x.fulfill()
         }.silenceWarning()
@@ -362,9 +362,9 @@ extension CatchableTests {
     func testCatchOnly_Type_PatternMatch_2() {
         let x = expectation(description: "Pattern match only Error.dummy")
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).catch(Error.dummy) {
             x.fulfill()
-        }.catchOnly(Error.self) { _ in
+        }.catch(Error.self) { _ in
             XCTFail()
             x.fulfill()
         }.silenceWarning()
@@ -375,7 +375,7 @@ extension CatchableTests {
     func testCatchOnly_Type_BaseCatchIsNotCalledAfterCatchOnlyExecutes() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).catchOnly(Error.self) { _ in
+        Promise<Int>(error: Error.dummy).catch(Error.self) { _ in
             x.fulfill()
         }.catch { _ in
             XCTFail()
@@ -388,7 +388,7 @@ extension CatchableTests {
     func testCatchOnly_Type_Cancellation_Ignore() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.cancelled).catchOnly(Error.self) { _ in
+        Promise<Int>(error: Error.cancelled).catch(Error.self) { _ in
             XCTFail()
             x.fulfill()
         }.catch(policy: .allErrors) { _ in
@@ -401,7 +401,7 @@ extension CatchableTests {
     func testCatchOnly_Type_Cancellation_Handle() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.cancelled).catchOnly(Error.self, policy: .allErrors) { _ in
+        Promise<Int>(error: Error.cancelled).catch(Error.self, policy: .allErrors) { _ in
             x.fulfill()
         }.catch { _ in
             XCTFail()
@@ -416,10 +416,10 @@ extension CatchableTests {
 
         enum Foo: Swift.Error { case bar }
 
-        Promise<Int>(error: Foo.bar).catchOnly(Error.dummy) {
+        Promise<Int>(error: Foo.bar).catch(Error.dummy) {
             XCTFail()
             x.fulfill()
-        }.catchOnly(Foo.self) { _ in
+        }.catch(Foo.self) { _ in
             x.fulfill()
         }.silenceWarning()
 
@@ -427,12 +427,12 @@ extension CatchableTests {
     }
 }
 
-/// `Promise<T>.recoverOnly`
+/// `Promise<T>.recover(_ only:)`
 extension CatchableTests {
     func testRecoverOnly_Object() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).recoverOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).recover(Error.dummy) {
             return Promise.value(1)
         }.done { _ in
             x.fulfill()
@@ -447,7 +447,7 @@ extension CatchableTests {
     func testRecoverOnly_Object_Ignored() {
         let x = expectation(description: #file + #function)
 
-        Promise.value(1).recoverOnly(Error.dummy) {
+        Promise.value(1).recover(Error.dummy) {
             return Promise(error: Error.dummy)
         }.done { _ in
             x.fulfill()
@@ -462,7 +462,7 @@ extension CatchableTests {
     func testRecoverOnly_Object_PatternMatch() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.cancelled).recoverOnly(Error.dummy) {
+        Promise<Int>(error: Error.cancelled).recover(Error.dummy) {
             return Promise.value(1)
         }.done { _ in
             XCTFail()
@@ -477,7 +477,7 @@ extension CatchableTests {
     func testRecoverOnly_Type() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).recoverOnly(Error.self) { _ in
+        Promise<Int>(error: Error.dummy).recover(Error.self) { _ in
             return Promise.value(1)
         }.done { _ in
             x.fulfill()
@@ -492,7 +492,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_Ignored() {
         let x = expectation(description: #file + #function)
 
-        Promise.value(1).recoverOnly(Error.self) { _ in
+        Promise.value(1).recover(Error.self) { _ in
             return Promise(error: Error.dummy)
         }.done { _ in
             x.fulfill()
@@ -509,7 +509,7 @@ extension CatchableTests {
 
         enum Foo: Swift.Error {}
 
-        Promise<Int>(error: Error.dummy).recoverOnly(Foo.self) { _ in
+        Promise<Int>(error: Error.dummy).recover(Foo.self) { _ in
             return Promise.value(1)
         }.done { _ in
             XCTFail()
@@ -524,7 +524,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_Cancellation_Ignore() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.cancelled).recoverOnly(Error.self) { _ in
+        Promise<Int>(error: Error.cancelled).recover(Error.self) { _ in
             return Promise.value(1)
         }.done { _ in
             XCTFail()
@@ -539,7 +539,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_Cancellation_Handle() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.cancelled).recoverOnly(Error.self, policy: .allErrors) { _ in
+        Promise<Int>(error: Error.cancelled).recover(Error.self, policy: .allErrors) { _ in
             return Promise.value(1)
         }.done { _ in
             x.fulfill()
@@ -556,9 +556,9 @@ extension CatchableTests {
 
         enum Foo: Swift.Error { case bar }
 
-        Promise<Int>(error: Error.dummy).recoverOnly(Foo.self) { _ in
+        Promise<Int>(error: Error.dummy).recover(Foo.self) { _ in
             return Promise(error: Foo.bar)
-        }.recoverOnly(Error.dummy) {
+        }.recover(Error.dummy) {
             return Promise.value(1)
         }.done { _ in
             x.fulfill()
@@ -573,7 +573,7 @@ extension CatchableTests {
     func testRecoverOnly_BaseRecoverIsNotCalledAfterRecoverOnlyExecutes() {
         let x = expectation(description: #file + #function)
 
-        Promise<Int>(error: Error.dummy).recoverOnly(Error.dummy) {
+        Promise<Int>(error: Error.dummy).recover(Error.dummy) {
             return Promise.value(1)
         }.recover { _ in
             return Promise(error: Error.dummy)
@@ -590,7 +590,7 @@ extension CatchableTests {
     func testRecoverOnly_Object_DoesNotReturnSelf() {
         let x = expectation(description: #file + #function)
         var promise: Promise<Void>!
-        promise = Promise<Void>(error: Error.dummy).recoverOnly(Error.dummy) { () -> Promise<Void> in
+        promise = Promise<Void>(error: Error.dummy).recover(Error.dummy) { () -> Promise<Void> in
             return promise
         }
         promise.catch { err in
@@ -605,7 +605,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_DoesNotReturnSelf() {
         let x = expectation(description: #file + #function)
         var promise: Promise<Void>!
-        promise = Promise<Void>(error: Error.dummy).recoverOnly(Error.self) { _ -> Promise<Void> in
+        promise = Promise<Void>(error: Error.dummy).recover(Error.self) { _ -> Promise<Void> in
             return promise
         }
         promise.catch { err in
@@ -618,12 +618,12 @@ extension CatchableTests {
     }
 }
 
-/// `Promise<Void>.recoverOnly`
+/// `Promise<Void>.recover(_ only:)`
 extension CatchableTests {
     func testRecoverOnly_Object_Void() {
         let x = expectation(description: #file + #function)
 
-        Promise<Void>(error: Error.dummy).recoverOnly(Error.dummy) {
+        Promise<Void>(error: Error.dummy).recover(Error.dummy) {
             return ()
         }.done {
             x.fulfill()
@@ -638,7 +638,7 @@ extension CatchableTests {
     func testRecoverOnly_Object_Void_Fufilled() {
         let x = expectation(description: #file + #function)
 
-        Promise<Void>.value(()).recoverOnly(Error.dummy) {
+        Promise<Void>.value(()).recover(Error.dummy) {
             XCTFail()
             x.fulfill()
         }.done {
@@ -653,7 +653,7 @@ extension CatchableTests {
 
         enum Foo: Swift.Error { case bar }
 
-        Promise<Void>(error: Error.dummy).recoverOnly(Foo.bar) {
+        Promise<Void>(error: Error.dummy).recover(Foo.bar) {
             XCTFail()
             x.fulfill()
         }.done {
@@ -669,7 +669,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_Void() {
         let x = expectation(description: #file + #function)
 
-        Promise<Void>(error: Error.dummy).recoverOnly(Error.self) { _ in }.done {
+        Promise<Void>(error: Error.dummy).recover(Error.self) { _ in }.done {
             x.fulfill()
         }.catch { _ in
             XCTFail()
@@ -682,7 +682,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_Void_Fufilled() {
         let x = expectation(description: #file + #function)
 
-        Promise<Void>.value(()).recoverOnly(Error.self) { _ in
+        Promise<Void>.value(()).recover(Error.self) { _ in
             XCTFail()
             x.fulfill()
         }.done {
@@ -697,7 +697,7 @@ extension CatchableTests {
 
         enum Foo: Swift.Error { case bar }
 
-        Promise<Void>(error: Error.dummy).recoverOnly(Foo.self) { _ in
+        Promise<Void>(error: Error.dummy).recover(Foo.self) { _ in
             XCTFail()
             x.fulfill()
         }.done {
@@ -713,7 +713,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_Void_Rethrow() {
         let x = expectation(description: #file + #function)
 
-        Promise<Void>(error: Error.dummy).recoverOnly(Error.self) { _ in
+        Promise<Void>(error: Error.dummy).recover(Error.self) { _ in
             throw Error.dummy
         }.done {
             XCTFail()
@@ -728,7 +728,7 @@ extension CatchableTests {
     func testRecoverOnly_Type_Void_Cancellation_Ignore() {
         let x = expectation(description: #file + #function)
 
-        Promise<Void>(error: Error.cancelled).recoverOnly(Error.self) { _ in }.done {
+        Promise<Void>(error: Error.cancelled).recover(Error.self) { _ in }.done {
             XCTFail()
             x.fulfill()
         }.catch(policy: .allErrors) { _ in

--- a/Tests/CorePromise/CatchableTests.swift
+++ b/Tests/CorePromise/CatchableTests.swift
@@ -257,6 +257,138 @@ extension CatchableTests {
     }
 }
 
+/// `Promise<T>.catchOnly`
+extension CatchableTests {
+    func testCatchOnly() {
+        let x = expectation(description: #file + #function)
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.dummy) { _ in
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_PatternMatch_1() {
+        let x = expectation(description: "Pattern match only Error.dummy")
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.dummy) { _ in
+            x.fulfill()
+        }.catchOnly(Error.cancelled) {
+            XCTFail("\($0) error was caught")
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_PatternMatch_2() {
+        let x = expectation(description: "Pattern match only Error.dummy")
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.cancelled) {
+            XCTFail("\($0) error was caught")
+            x.fulfill()
+        }.catchOnly(Error.dummy) { _ in
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_BaseCatchIsNotCalledAfterCatchOnlyExecutes() {
+        let x = expectation(description: #file + #function)
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.dummy) { _ in
+            x.fulfill()
+        }.catch { _ in
+            XCTFail()
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_BaseCatchIsCalledWhenCatchOnlyDoesNotExecute() {
+        let x = expectation(description: #file + #function)
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.cancelled) { _ in
+            XCTFail()
+            x.fulfill()
+        }.catch { _ in
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_Type() {
+        let x = expectation(description: #file + #function)
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.self) { _ in
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_Type_PatternMatch_1() {
+        let x = expectation(description: "Pattern match only Error.Type")
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.self) { _ in
+            x.fulfill()
+        }.catchOnly(Error.dummy) {
+            XCTFail("\($0) error was caught")
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_Type_PatternMatch_2() {
+        let x = expectation(description: "Pattern match only Error.dummy")
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.dummy) { _ in
+            x.fulfill()
+        }.catchOnly(Error.self) {
+            XCTFail("\($0) error was caught")
+            x.fulfill()
+        }.silenceWarning()
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_Type_BaseCatchIsNotCalledAfterCatchOnlyExecutes() {
+        let x = expectation(description: #file + #function)
+
+        Promise.value(1).then { _ -> Promise<Void> in
+            throw Error.dummy
+        }.catchOnly(Error.self) { _ in
+            x.fulfill()
+        }.catch { _ in
+            XCTFail()
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+}
+
 private enum Error: CancellableError {
     case dummy
     case cancelled

--- a/Tests/CorePromise/CatchableTests.swift
+++ b/Tests/CorePromise/CatchableTests.swift
@@ -387,6 +387,32 @@ extension CatchableTests {
 
         wait(for: [x], timeout: 5)
     }
+
+    func testCatchOnly_Type_Cancellation_Ignore() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Int>(error: Error.cancelled).catchOnly(Error.self) { _ in
+            XCTFail()
+            x.fulfill()
+        }.catch(policy: .allErrors) { _ in
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
+
+    func testCatchOnly_Type_Cancellation_Handle() {
+        let x = expectation(description: #file + #function)
+
+        Promise<Int>(error: Error.cancelled).catchOnly(Error.self, policy: .allErrors) { _ in
+            x.fulfill()
+        }.catch { _ in
+            XCTFail()
+            x.fulfill()
+        }
+
+        wait(for: [x], timeout: 5)
+    }
 }
 
 private enum Error: CancellableError {

--- a/Tests/CorePromise/Utilities.swift
+++ b/Tests/CorePromise/Utilities.swift
@@ -4,6 +4,10 @@ extension Promise {
     func silenceWarning() {}
 }
 
+extension PMKCascadingFinalizer {
+    func silenceWarning() {}
+}
+
 #if os(Linux)
 import func CoreFoundation._CFIsMainThread
 


### PR DESCRIPTION
## Intro
Currently all errors in a promise chain propagate down to a single `catch` handler at the end. Therein, the identity of the error must often be reasoned out with comparative statements and then handled according to its identity. This can lead to otherwise clean chains becoming bottom-heavy with logic in the `catch`.

Swift's do-catch provides for error pattern matching in its catch handlers, raising the error identification logic up one level. This PR provides an implementation to introduce this pattern into PromiseKit, allowing for separate catch handlers for specific errors.

_refs #639_

## Usage
The new `catchOnly` method included in this PR works the same as the current `catch` method, except that it takes a required `Error` parameter, and only executes its handler if the promise chain rejects with that error.

```swift
firstly {
    API.findUser(named: "Taylor")
}.done { user in
    //…
}.catchOnly(API.Error.noResults) {
    //Let the user know there's no results for their query
}.catch { error in
    //Handle other errors like timeouts
}
```

In the above, the `catchOnly` handler would only execute if the API request rejected with a `noResults` error. The final `catch` handler would then no longer execute since the error was already handled. Likewise, if some other error occurred, the `catchOnly` handler would be skipped and only the final `catch` handler would be executed.

An arbitrary number of `catchOnly` calls may be chained, but the chain must still be terminated with a final `catch`. An overload for `catchOnly` which takes a type instead of an object is also provided for matching on a family of errors.

## Implementation
The new functions work similarly to the current `catch` function, only instead of returning a `PMKFinalizer` they return a void promise which is fulfilled if the error is handled (or if the promise was fulfilled), and rejected with the unhandled error otherwise to allow it to propagate to successive catch handlers.

Since no changes were made to existing API or implementations, a major version rev should not be necessary. I have included some trivial tests in the PR as evidence that the new functions behave as intended, but I am happy to flesh these out or strip them entirely upon request.

I've not included any implementation for the Objective-C interface (not sure if it's necessary or even desired). But I am happy to do so if requested.

Ideally, I would have preferred a simple `catch(Error.someError)` signature both for succinctness and keeping in line with Swift's do-catch, but it surfaced the usual compiler confusion that PMK's overloads have dealt with in the past. I settled on `catchOnly` to get around this, but I actually rather like it now, and its visual distinctness in code from the base `catch` is probably for the best. Still, open to name changes, of course.

## Limitations
Since the new `catchOnly` functions return a promise, it is possible to chain off of them with functions other than `catchOnly` and `catch`. This isn't desirable, but is also unlikely to to be utilized, I believe, since the underlying value from the promise would have been consumed by `catchOnly`. A chained `then` or `done` for instance would have no context. I had originally intended to return a `PMKFinalizer` to avoid this, but that solution quickly proved to have too many issues.

Error objects with associated values, while technically supported, make little sense in the usage of `catchOnly` since concrete associated values would need to be supplied in order to pattern match. However, the type-accepting overload of `catchOnly` can still prove useful in these cases.

Errors passed in must conform to `Equatable`, but this is given for free in most situations in Swift 4 now.

## Alternatives
`recover` may already be used in a similar manner to `catchOnly` (as described in #639). And this doesn't appear to be a hotly requested or needed feature by any means. So, leaving it out of PromiseKit probably isn't going to cause any friction.