### PR TITLE
Create void fulfill function

### DIFF
--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -65,6 +65,11 @@ extension Resolver where T == Void {
             fulfill(())
         }
     }
+
+    // Fulfills the promise
+    public func fulfill() {
+        self.fulfill(())
+    }
 }
 #endif
 


### PR DESCRIPTION
Hello everybody

I find it annoying to have to add a Void value every time I need to fulfill a Void promise. It can also be confusing how to fulfill Void promises for people who are not familiar with how to instantiate a Void value.

This PR would allow users to replace this syntax
```
resolver.fulfill(())
```

with 

```
resolver.fulfill()
```

Thanks!