### PR TITLE
Use PackageDescription API v4 in Installation.md

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -39,9 +39,9 @@ github "mxcl/PromiseKit" ~> 6.0
 
 ## SwiftPM
 
-```ruby
+```swift
 package.dependencies.append(
-    .Package(url: "https://github.com/mxcl/PromiseKit", majorVersion: 6)
+    .package(url: "https://github.com/mxcl/PromiseKit", from: "6.0.0")
 )
 ```
 


### PR DESCRIPTION
Updates Installation.md to use PackageDescription API v4

Also uses Swift syntax highlighting instead of ruby