### PR TITLE
Adding more queue async functions.

### DIFF
--- a/Tests/CorePromise/GuaranteeTests.swift
+++ b/Tests/CorePromise/GuaranteeTests.swift
@@ -30,4 +30,52 @@ class GuaranteeTests: XCTestCase {
 
         wait(for: [ex], timeout: 10)
     }
+
+    // MARK: - Dispatching to queues
+
+    @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
+    func testDispatchQueueAsyncExtensionReturnsGuarantee() {
+        let ex = expectation(description: "")
+
+        DispatchQueue.global().async(.promise) { () -> Int in
+            XCTAssertFalse(Thread.isMainThread)
+            return 1
+            }.done { one in
+                XCTAssertEqual(one, 1)
+                ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
+    func testDispatchQueueAsyncGuaranteeExtensionReturnsGuarantee() {
+        let ex = expectation(description: "")
+
+        DispatchQueue.global().asyncGuarantee(Int.self) {
+            XCTAssertFalse(Thread.isMainThread)
+            return 1
+            }.done { one in
+                XCTAssertEqual(one, 1)
+                ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
+    func testDispatchQueueAsyncSealableGuaranteeWithSealExtensionReturnsGuarantee() {
+        let ex = expectation(description: "")
+
+        DispatchQueue.global().asyncGuarantee(Int.self) { seal in
+            XCTAssertFalse(Thread.isMainThread)
+            seal(1)
+            }.done { one in
+                XCTAssertEqual(one, 1)
+                ex.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
 }


### PR DESCRIPTION
# Additional extension functions for queuing initial promises 

## The problem

I was attempting to create a new promise on a background queue and felt the way I had to do it wasn't as easy or as nice as I'd like it to be. My problem was that I needed it to execute some code that contained more asynchronous functionality.  So I ended up with something like this (very simplified example):

```swift
return Promise<Int> { seal in
    backgroundQueue.async {
         seal.fulfill(5)
    }
}
```

After looking at the PromiseKit async extensions I had a few things about it I wanted to change:

* Even though they could produce both promises and guarantees, there was nothing in the signature to make it clear to other developers. ie:

    ```swift
    // Guarantee
    backgroundQueue.async(.promise) { () -> Int in
        return 5
    }

    // Promise
    backgroundQueue.async(.promise) { () -> Int in
        return 5
    }.catch { error in
        //...
    }
    ```
* Apart from the `catch` closure there's no way to tell whether it's a promise or guarantee coming back.
* Even when returning a guarantee, the function 'asks' for a promise with the `.promise` argument. 
* As per the code above, the `async(...)` function could not pass a resolver for sealing.

## Proposed solution in this PR

This PR contains code that does this:

* Adds new async methods with these signatures:
 
    ```swift
    func asyncPromise<T>(_ ofType: T.Type, ..., execute body: @escaping () throws -> T) -> Promise<T>
    final func asyncPromise<T>(_ ofType:T.Type, ..., resolver body: @escaping (Resolver<T>) -> Void) -> Promise<T>
    func asyncGuarantee<T>(_ ofType: T.Type, ..., execute body: @escaping () throws -> T) -> Guarantee<T>
    final func asyncGuarantee<T>(_ ofType:T.Type, ..., resolver body: @escaping (Resolver<T>) -> Void) -> Guarantee<T>
    ```

This lets you write code like this:

```swift
// Guarantee
backgroundQueue.asyncGuarantee(Int.self) {
    return 5
}
backgroundQueue.asyncGuarantee(Int.self) { seal in
    seal.fulfill(5)
}

// Promise
backgroundQueue.asyncPromise(Int.self) {
    return 5
}.catch { error in
    //...
}
backgroundQueue.asyncPromise(Int.self) { seal in
    seal.fulfill(5)
}.catch { error in
    //...
}
```

Please see the unit tests for working examples. The advantages of these options (as I see them) are:

* Each call is as close as I can get it to declaring a normal promise or guarantee. ie. `q.asyncPromise(Int.self) {...` reads like `Promise<Int> {...`.
* It's clear whether you are creating a promise or guarantee. I also tried a style using the established `.async(.promise) {` style to add the sealable methods, but didn't like they way they turned out.
* The closure's no longer need to have argument types declared. They are now inferred.

Please feel free to get back to me with ideas and comments.

Thanks
Derek
