### PR TITLE
All changes should do a full lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ jobs:
     - <<: *pod
       osx_image: xcode10.1
       env: SWIFT=4.2
-      name: pod lib lint --swift-version=4.2
+      name: pod lib lint --all-subspecs --swift-version=4.2
+      script: pod lib lint --fail-fast --swift-version=$SWIFT
 
     - &linux
       stage: compile

--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -62,14 +62,23 @@ extension Resolver where T == Void {
         if let error = error {
             reject(error)
         } else {
-            fulfill()
+            fulfill(())
         }
     }
+#if false
+    // disabled ∵ https://github.com/mxcl/PromiseKit/issues/990
 
     /// Fulfills the promise
     public func fulfill() {
         self.fulfill(())
     }
+#else
+    /// Fulfills the promise
+    /// - Note: underscore is present due to: https://github.com/mxcl/PromiseKit/issues/990
+    public func fulfill_() {
+        self.fulfill(())
+    }
+#endif
 }
 #endif
 

--- a/Tests/A+/0.0.0.swift
+++ b/Tests/A+/0.0.0.swift
@@ -26,7 +26,7 @@ extension XCTestCase {
         let (pending, seal) = Promise<Void>.pending()
 
         do {
-            try body((pending, { seal.fulfill() }, seal.reject), expectation)
+            try body((pending, seal.fulfill_, seal.reject), expectation)
             waitForExpectations(timeout: timeout) { err in
                 if let _ = err {
                     XCTFail("wait failed: \(description)", file: file, line: line)

--- a/Tests/CorePromise/ResolverTests.swift
+++ b/Tests/CorePromise/ResolverTests.swift
@@ -159,6 +159,25 @@ class WrapTests: XCTestCase {
         }
         wait(for: [ex], timeout: 10)
     }
+
+    func testVoidResolverFulfillAmbiguity() {
+
+        // reference: https://github.com/mxcl/PromiseKit/issues/990
+
+        func foo(success: () -> Void, failure: (Error) -> Void) {
+            success()
+        }
+
+        func bar() -> Promise<Void> {
+            return Promise<Void> { (seal: Resolver<Void>) in
+                foo(success: seal.fulfill, failure: seal.reject)
+            }
+        }
+
+        let ex = expectation(description: "")
+        bar().done(ex.fulfill).cauterize()
+        wait(for: [ex], timeout: 10)
+    }
 }
 
 private enum Error: Swift.Error {

--- a/Tests/CorePromise/WhenResolvedTests.swift
+++ b/Tests/CorePromise/WhenResolvedTests.swift
@@ -29,13 +29,13 @@ class JoinTests: XCTestCase {
         when(resolved: promise1, promise2, promise3).done(on: nil) { _ in finished = true }
         XCTAssertFalse(finished, "Not all promises have resolved")
         
-        seal1.fulfill()
+        seal1.fulfill_()
         XCTAssertFalse(finished, "Not all promises have resolved")
         
-        seal2.fulfill()
+        seal2.fulfill_()
         XCTAssertFalse(finished, "Not all promises have resolved")
         
-        seal3.fulfill()
+        seal3.fulfill_()
         XCTAssert(finished, "All promises have resolved")
     }
 }


### PR DESCRIPTION
For example, we did not verify that a recent change would not affect compilation of all extensions which may have caused a bug: #990