### PR TITLE
Make umbrella header import all public .h files with proper public import syntax

### DIFF
--- a/Sources/PromiseKit.h
+++ b/Sources/PromiseKit.h
@@ -1,7 +1,12 @@
-#import "fwd.h"
-#import "AnyPromise.h"
-
 #import <Foundation/NSObjCRuntime.h>  // `FOUNDATION_EXPORT`
 
 FOUNDATION_EXPORT double PromiseKitVersionNumber;
 FOUNDATION_EXPORT const unsigned char PromiseKitVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <PromiseKit/PublicHeader.h>
+
+#import <PromiseKit/AnyPromise.h>
+#import <PromiseKit/CLGeocoder+AnyPromise.h>
+#import <PromiseKit/CLLocationManager+AnyPromise.h>
+#import <PromiseKit/fwd.h>
+#import <PromiseKit/PMKCoreLocation.h>


### PR DESCRIPTION
Umbrella headers need to import all public Objective-C header files. Without this, projects may get compiler warnings like: `/<module-includes>:1:1: Umbrella header for module 'PromiseKit' does not include header 'PMKCoreLocation.h'`

This PR adds all public header files to the PromiseKit umbrella header. It also changes the import syntax to use `#import <PromiseKit/PublicHeader.h>`, which is the proper way to import module-specific files in a public header.