### PR TITLE
Final cleanup for Dispatcher conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ branches:
   only:
     - master
     - v4
-    - v7
+    - /^v7/
     - legacy-1.x
     - /^\d+\.\d+\.\d+$/
 

--- a/Documents/Appendix.md
+++ b/Documents/Appendix.md
@@ -209,3 +209,45 @@ its work on a background thread.
 
 Promises abstract asynchronicity, so exploit and support that model. Design your
 APIs so that consumers don’t have to care what queue your functions run on.
+
+##  `Dispatcher` Objects
+
+Some issues are best addressed at the level of dispatching. For example, you may need
+to perform a series of HTTP transactions on a server that allows only a certain number of
+API calls per minute. Or, you might want to allow only a certain number of memory-hungry
+background tasks to run at once. These aren't really promise-level concerns; they just have
+to do with the details of how closures are invoked once they become eligible to run.
+
+Unfortunately, `DispatchQueue`s don't directly support these types of restrictions, and because
+of the way `DispatchQueue` is implemented, you can't create your own subclasses. PromiseKit 7 
+adds an abstract `Dispatcher` protocol that generalizes the idea of a dispatch queue and allows for
+alternate implementations:
+
+```swift
+public protocol Dispatcher {
+    func dispatch(_ body: @escaping () -> Void)
+}
+```
+
+Anywhere in PromiseKit that you can use a `DispatchQueue`, you're free to substitute a `Dispatcher`. 
+
+PromiseKit doesn't care how you implement `dispatch()`. You can run the provided closure synchronously or
+asynchronously, now or at some point in the future, on any thread you wish. Of course, your own code 
+must have a thread safety strategy and not create deadlocks.
+
+If you're setting a default dispatcher, assign your dispatcher to `PromiseKit.conf.D` rather than `PromiseKit.conf.Q`; the latter
+accepts only `DispatchQueue`s.
+
+**FIXME: Check locations and availability of Dispatcher implementations before release**
+
+A few handy `Dispatcher` types are available in the `Dispatchers` extension library:
+
+* `RateLimitedDispatcher` implements general dispatch rate limits with an approximate "token bucket" strategy.
+* `StrictRateLimitedDispatcher` is an exact and optimal "sliding window" rate limiter, but requires O(n) space (n = # of events/time)
+* `ConcurrencyLimitedDispatcher` allows only *n* asynchronous closures to run at once.
+* `CoreDataDispatcher` lets you dispatch onto threads associated with `NSManagedObjectContext`s.
+
+A couple of `Dispatcher`s are also included in the PromiseKit core: 
+
+* `CurrentThreadDispatcher` runs closures immediately, on the current thread.
+* `DispatchQueueDispatcher` forwards to a `DispatchQueue`, applying a static `DispatchGroup`, quality of service, and flag set.

--- a/Documents/CommonPatterns.md
+++ b/Documents/CommonPatterns.md
@@ -82,8 +82,10 @@ class MyRestAPI {
 }
 ```
 
-All PromiseKit handlers take an `on` parameter that lets you designate the dispatch queue
-on which to run the handler. The default is always the main queue.
+All PromiseKit handlers take an `on` parameter that lets you designate a `Dispatcher` that
+will run the handler. Usually, the dispatcher is just a plain-vanilla `DispatchQueue`, but you
+can write your own if you like. The default is always `DispatchQueue.main`, which is a
+serial (nonconcurrent) queue.
 
 PromiseKit is *entirely* thread safe.
 

--- a/Documents/FAQ.md
+++ b/Documents/FAQ.md
@@ -8,7 +8,7 @@
 * Do you want a library that has been maintained continuously and passionately for 6 years? Then pick PromiseKit.
 * Do you want a library that the community has chosen to be their №1 Promises/Futures library? Then pick PromiseKit.
 * Do you want to be able to use Promises with Apple’s SDKs rather than having to do all the work of writing the Promise implementations yourself? Then pick PromiseKit.
-* Do you want to be able to use Promises with Swift 3.x, Swift 4.x, ObjC, iOS, tvOS, watchOS, macOS, Android & Linux? Then pick PromiseKit.
+* Do you want to be able to use Promises with Swift, ObjC, iOS, tvOS, watchOS, macOS, Android & Linux? Then pick PromiseKit.
 * PromiseKit verifies its correctness by testing against the entire [Promises/A+ test suite](https://github.com/promises-aplus/promises-tests).
 
 ## How do I create a fulfilled `Void` promise?
@@ -229,8 +229,8 @@ So, RxSwift tries hard to supply every operator you might ever want to use right
 hundreds. PromiseKit supplies a few utilities to help with specific scenarios, but because it's trivial
 to write your own chain elements, there's no need for all this extra code in the library.
 
-* PromiseKit dispatches the execution of every block. RxSwift dispatches only when told to do so. Moreover, the 
-current dispatching state is an attribute of the chain, not the specific block, as it is in PromiseKit.
+* PromiseKit dispatches the execution of every block. RxSwift dispatches only when told to do so. Moreover, 
+in RxSwift, the current dispatching state is an attribute of the chain, not the specific block, as it is in PromiseKit.
 The RxSwift system is more powerful but more complex. PromiseKit is simple, predictable and safe.
 
 * In PromiseKit, both sides of a branched chain refer back to their shared common ancestors. In RxSwift, 
@@ -307,36 +307,56 @@ feature because it gives you guarantees about the flow of your chains.
 
 ## How do I change the default queues that handlers run on?
 
-You can change the values of `PromiseKit.conf.Q`. There are two variables that
-change the default queues that the two kinds of handler run on. A typical
-pattern is to change all your `then`-type handlers to run on a background queue
+You can change the values of `PromiseKit.conf.Q` or `PromiseKit.conf.D`. These 
+variables both access the same underlying state. However,  `conf.Q` presents it in terms of 
+`DispatchQueue`s, while `conf.D` presents it in terms of the more general
+`Dispatcher`-protocol objects that PromiseKit uses internally. (`DispatchQueue`s are
+just one possible implementation of `Dispatcher`, although they are the ones that account
+for nearly all actual use.)
+
+Each of these configuration variables is a two-tuple that identifies two separate dispatchers named `map` and `return`.
+
+```swift
+public var Q: (map: DispatchQueue?, return: DispatchQueue?)
+public var D: (map: Dispatcher, return: Dispatcher)
+```
+
+The `return` dispatcher is the default for chain-finalizing methods such as `done`
+and `catch`. The `map` dispatcher is the default for everything else. A
+typical pattern is to change all your `then`-type handlers to run on a background queue
 and to have all your “finalizers” run on the main queue:
 
 ```
 PromiseKit.conf.Q.map = .global()
-PromiseKit.conf.Q.return = .main  //NOTE this is the default
+PromiseKit.conf.Q.return = .main
 ```
 
-Be very careful about setting either of these queues to `nil`.  It has the
-effect of running *immediately*, and this is not what you usually want to do in
-your application.  This is, however, useful when you are running specs and want
-your promises to resolve immediately. (This is basically the same idea as "stubbing"
-an HTTP request.)
+Note that `DispatchQueue.main` is the default for _both_ dispatchers.
+
+Be very careful about setting either part of `conf.Q` to `nil`.  It has the
+effect of running closures *immediately*, and this is not what you usually want to do in
+your application.  It is useful, however, when you are running specs and want
+your promises to resolve immediately. (It's basically the same idea as "stubbing"
+HTTP requests.)
 
 ```swift
 // in your test suite setup code
-PromiseKit.conf.Q.map = nil
-PromiseKit.conf.Q.return = nil
+PromiseKit.conf.Q = (map: nil, return: nil)
 ```
 
 ## How do I use PromiseKit on the server side?
 
 If your server framework requires that the main queue remain unused (e.g., Kitura),
-then you must use PromiseKit 6 and you must tell PromiseKit not to dispatch to the
-main queue by default. This is easy enough:
+then you must tell PromiseKit not to dispatch there by default. This is easy enough:
 
 ```swift
-PromiseKit.conf.Q = (map: DispatchQueue.global(), return: DispatchQueue.global())
+PromiseKit.conf.Q = (map: .global(), return: .global())
+```
+If you want to emulate the serializing behavior of `DispatchQueue.main`, just create and label
+a new `DispatchQueue`. It'll be serial by default.
+
+```swift
+PromiseKit.conf.Q.return = DispatchQueue(label: "virtual main queue")
 ```
 
 > Note, we recommend using your own queue rather than `.global()`, we've seen better performance this way.
@@ -372,12 +392,12 @@ Kitura.run()
 
 ## How do I control console output?
 
-By default PromiseKit emits console messages when certain events occur.  These events include:
+By default, PromiseKit emits warning messages on the console when certain events occur.  These events include:
 - A promise or guarantee has blocked the main thread
 - A promise has been deallocated without being fulfilled
 - An error which occurred while fulfilling a promise was swallowed using cauterize
 
-You may turn off or redirect this output by setting a thread safe closure in [PMKCOnfiguration](https://github.com/mxcl/PromiseKit/blob/master/Sources/Configuration.swift) **before** processing any promises. For example, to turn off console output:
+You may turn off or redirect this output by setting a thread-safe closure in [PMKCOnfiguration](https://github.com/mxcl/PromiseKit/blob/master/Sources/Configuration.swift) **before** processing any promises. For example, to turn off console output:
 
 ```swift
 conf.logHandler = { event in }

--- a/Documents/GettingStarted.md
+++ b/Documents/GettingStarted.md
@@ -58,7 +58,7 @@ that represents the type of object it wraps. For example, in the example above,
 `login` is a function that returns a `Promise` that *will* represent an instance
 of `Creds`.
 
-> *Note*: `done` is new to PromiseKit 5. We previously defined a variant of `then` that
+> *Note*: `done` was introduced in PromiseKit 5. We previously defined a variant of `then` that
 did not require you to return a promise. Unfortunately, this convention often confused
 Swift and led to odd and hard-to-debug error messages. It also made using PromiseKit 
 more painful. The introduction of `done` lets you type out promise chains that
@@ -311,10 +311,10 @@ extra disambiguation for the Swift compiler. Sorry; we tried.
 typically just pass completion handler parameters to `resolve` and let Swift figure
 out which variant to apply to your particular case (as shown in the example above).
 
-> *Note* `Guarantees` (below) have a slightly different initializer (since they
-cannot error) so the parameter to the initializer closure is just a closure. Not
-a `Resolver` object. Thus do `seal(value)` rather than `seal.fulfill(value)`. This
-is because there is no variations in what guarantees can be sealed with, they can
+> *Note*: `Guarantee`s (below) have a slightly different initializer since they
+cannot error, so the parameter to the initializer closure is just a closure. Not
+a `Resolver` object. Just do `seal(value)` rather than `seal.fulfill(value)`. It's
+different because there is only one way to seal guarantees; they can
 *only* fulfill.
 
 # `Guarantee<T>`
@@ -346,7 +346,7 @@ if you find an issue.
 
 ---
 
-If you are creating your own guarantees the syntax is simpler than that of promises;
+If you are creating your own guarantees the syntax is simpler than that of promises:
 
 ```swift
 func fetch() -> Promise<String> {
@@ -507,7 +507,7 @@ However, this shorthand is both a blessing and a curse. You may find that the Sw
 often fails to infer return types properly. See our [Troubleshooting Guide](Troubleshooting.md) if
 you require further assistance.
 
-> By adding `done` to PromiseKit 5, we have managed to avoid many of these common
+> By adding `done` to PromiseKit 5, we were able to blunt many of these common
 pain points in using PromiseKit and Swift.
 
 
@@ -527,9 +527,9 @@ Here are some recent articles that document PromiseKit 5+:
 
 * [Using Promises - Agostini.tech](https://agostini.tech/2018/10/08/using-promisekit)
 
-Careful with general online references, many of them refer to PMK < 5 which has a subtly
-different API (sorry about that, but Swift has changed a lot over the years and thus
-we had to too).
+Be careful when consulting general online references, as many of them refer to PMK < 5, which has a subtly
+different API. (Sorry about that, but Swift has changed a lot over the years and thus
+we had to as well.)
 
 
 [API Reference]: https://mxcl.github.io/PromiseKit/reference/v7/Classes/Promise.html

--- a/Documents/Troubleshooting.md
+++ b/Documents/Troubleshooting.md
@@ -68,7 +68,7 @@ return firstly {
 }
 ```
 
-We have made great effort to reduce the need for explicit typing in PromiseKit 6, 
+We have made great effort to reduce the need for explicit typing in PromiseKit, 
 but as with all Swift functions that return a generic type (e.g., `Array.map`),
 you may need to explicitly tell Swift what a closure returns if the closure's body is
 longer than one line.
@@ -175,17 +175,17 @@ All PromiseKit functions are documented and provide examples.
 
 You have a `then`; you want a `done`.
 
-## "Missing argument for parameter #1 in call"
+## "Missing argument for parameter #1 in call" "Unable to infer closure type in the current context"
 
 This is part of Swift 4’s “tuplegate”.
 
-You must specify your `Void` parameter:
+You must fulfill a `Promise<Void>` with an explicit `Void` parameter:
 
 ```swift
 seal.fulfill(())
 ```
 
-Yes: we hope they revert this change in Swift 5 too.
+This wart remains in Swift 5, too. It's probably not going to change.
 
 ## "Ambiguous reference to 'firstly(execute:)'"
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ PromiseKit 7 is pre-release, if you’re using it: beware!
 
 PromiseKit 7 uses Swift 5’s `Result`, PromiseKit <7 use our own `Result` type.
 
+PromiseKit 7 generalizes `DispatchQueue`s to a `Dispatcher` protocol. However, `DispatchQueue`s are `Dispatcher`-conformant,
+so existing code should not need to change. Please report any issues related to this transition.  
+
 # Quick Start
 
 In your [Podfile]:
@@ -88,14 +91,14 @@ wage*. Please help me continue my work, I appreciate it 🙏🏻
 # Documentation
 
 * Handbook
-  * [Getting Started](Documentation/GettingStarted.md)
-  * [Promises: Common Patterns](Documentation/CommonPatterns.md)
-  * [Frequently Asked Questions](Documentation/FAQ.md)
+  * [Getting Started](Documents/GettingStarted.md)
+  * [Promises: Common Patterns](Documents/CommonPatterns.md)
+  * [Frequently Asked Questions](Documents/FAQ.md)
 * Manual
-  * [Installation Guide](Documentation/Installation.md)
-  * [Objective-C Guide](Documentation/ObjectiveC.md)
-  * [Troubleshooting](Documentation/Troubleshooting.md) (e.g., solutions to common compile errors)
-  * [Appendix](Documentation/Appendix.md)
+  * [Installation Guide](Documents/Installation.md)
+  * [Objective-C Guide](Documents/ObjectiveC.md)
+  * [Troubleshooting](Documents/Troubleshooting.md) (e.g., solutions to common compile errors)
+  * [Appendix](Documents/Appendix.md)
 * [API Reference](https://mxcl.github.io/PromiseKit/reference/v7/Classes/Promise.html)
 
 # Extensions
@@ -171,7 +174,7 @@ but nowadays it isn’t really necessary.
 
 # Support
 
-Please check our [Troubleshooting Guide](Documentation/Troubleshooting.md), and
+Please check our [Troubleshooting Guide](Documents/Troubleshooting.md), and
 if after that you still have a question, ask at our [Gitter chat channel] or on [our bug tracker].
 
 # Contributing
@@ -193,7 +196,7 @@ Generate the Xcode project:
 [our bug tracker]: https://github.com/mxcl/PromiseKit/issues/new
 [Podfile]: https://guides.cocoapods.org/syntax/podfile.html
 [PMK6]: http://mxcl.github.io/PromiseKit/news/2018/02/PromiseKit-6.0-Released/
-[Installation Guide]: Documentation/Installation.md
+[Installation Guide]: Documents/Installation.md
 [badge-travis]: https://travis-ci.org/mxcl/PromiseKit.svg?branch=master
 [travis]: https://travis-ci.org/mxcl/PromiseKit
 [cocoapods]: https://cocoapods.org/pods/PromiseKit

--- a/Sources/Catchable.swift
+++ b/Sources/Catchable.swift
@@ -18,7 +18,7 @@ public extension CatchMixin {
      - Parameter policy: The default policy does not execute your handler for cancellation errors.
      - Parameter execute: The handler to execute if this promise is rejected.
      - Returns: A promise finalizer.
-     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation)
+     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation)
      */
     @discardableResult
     func `catch`(on: Dispatcher = conf.D.return, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) -> Void) -> PMKFinalizer {
@@ -70,7 +70,7 @@ public extension CatchMixin {
      
      - Parameter on: The dispatcher that executes the provided closure.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation)
+     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation)
      */
     func recover<U: Thenable>(on: Dispatcher = conf.D.map, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) throws -> U) -> Promise<T> where U.T == T {
         let rp = Promise<U.T>(.pending)
@@ -103,7 +103,7 @@ public extension CatchMixin {
      - Note it is logically impossible for this to take a `catchPolicy`, thus `allErrors` are handled.
      - Parameter on: The dispatcher that executes the provided closure.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation)
+     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation)
      */
     @discardableResult
     func recover(on: Dispatcher = conf.D.map, _ body: @escaping(Error) -> Guarantee<T>) -> Guarantee<T> {
@@ -202,7 +202,7 @@ public extension CatchMixin where T == Void {
      
      - Parameter on: The dispatcher that executes the provided closure.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation)
+     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation)
      */
     @discardableResult
     func recover(on: Dispatcher = conf.D.map, _ body: @escaping(Error) -> Void) -> Guarantee<Void> {
@@ -228,7 +228,7 @@ public extension CatchMixin where T == Void {
      
      - Parameter on: The dispatcher that executes the provided closure.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation)
+     - SeeAlso: [Cancellation](https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation)
      */
     func recover(on: Dispatcher = conf.D.map, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) throws -> Void) -> Promise<Void> {
         let rg = Promise<Void>(.pending)

--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -8,13 +8,17 @@ import Dispatch
  We would like it to be, but sadly `Swift` does not expose `dispatch_once` et al. which is what we used to use in order to make the configuration immutable once first used.
 */
 public struct PMKConfiguration {
-    /// Backward compatibility: default DispatchQueues that promise handlers dispatch to
+    /// Backward compatibility: the default Dispatcher to which handlers dispatch, represented as DispatchQueues.
     public var Q: (map: DispatchQueue?, return: DispatchQueue?) {
-        get { return (map: D.map as? DispatchQueue, return: D.return as? DispatchQueue) }
+        get {
+            let convertedMap = D.map is CurrentThreadDispatcher ? nil : D.map as? DispatchQueue
+            let convertedReturn = D.return is CurrentThreadDispatcher ? nil : D.return as? DispatchQueue
+            return (map: convertedMap, return: convertedReturn)
+        }
         set { D = (map: newValue.map ?? CurrentThreadDispatcher(), return: newValue.return ?? CurrentThreadDispatcher()) }
     }
 
-    /// The default Dispatchers that promise handlers dispatch to
+    /// The default Dispatchers to which promise handlers dispatch
     public var D: (map: Dispatcher, return: Dispatcher) = (map: DispatchQueue.main, return: DispatchQueue.main)
 
     /// The default catch-policy for all `catch` and `resolve`
@@ -24,16 +28,7 @@ public struct PMKConfiguration {
     /// Not thread safe; change before processing any promises.
     /// - Note: The default handler calls `print()`
     public var logHandler: (LogEvent) -> () = { event in
-        switch event {
-        case .waitOnMainThread:
-            print("PromiseKit: warning: `wait()` called on main thread!")
-        case .pendingPromiseDeallocated:
-            print("PromiseKit: warning: pending promise deallocated")
-        case .pendingGuaranteeDeallocated:
-            print("PromiseKit: warning: pending guarantee deallocated")
-        case .cauterized (let error):
-            print("PromiseKit:cauterized-error: \(error)")
-        }
+        print(event.asString())
     }
 }
 

--- a/Sources/Dispatcher.swift
+++ b/Sources/Dispatcher.swift
@@ -93,7 +93,7 @@ public extension DispatchQueue {
 fileprivate func selectDispatcher(given: DispatchQueue?, configured: Dispatcher, flags: DispatchWorkItemFlags?) -> Dispatcher {
     guard let given = given else {
         if flags != nil {
-            print("PromiseKit: warning: nil DispatchQueue specified, but DispatchWorkItemFlags were also supplied (ignored)")
+            conf.logHandler(.nilDispatchQueueWithFlags)
         }
         return CurrentThreadDispatcher()
     }
@@ -102,7 +102,7 @@ fileprivate func selectDispatcher(given: DispatchQueue?, configured: Dispatcher,
     } else if let flags = flags, let configured = configured as? DispatchQueue {
         return configured.asDispatcher(withFlags: flags)
     } else if flags != nil {
-        print("PromiseKit: warning: DispatchWorkItemFlags flags specified, but default Dispatcher is not a DispatchQueue (ignored)")
+        conf.logHandler(.extraneousFlagsSpecified)
     }
     return configured
 }

--- a/Sources/Dispatcher.swift
+++ b/Sources/Dispatcher.swift
@@ -6,16 +6,9 @@ import Dispatch
 ///
 /// `Dispatcher`s define a `dispatch` method that executes a supplied closure.
 /// Execution may be synchronous or asynchronous, serial
-/// or concurrent.
+/// or concurrent, and can occur on any thread.
 ///
 /// All `DispatchQueue`s are also valid `Dispatcher`s.
-///
-/// - SeeAlso:
-///   - `RateLimitedDispatcher`
-///   - `StrictRateLimitedDispatcher`
-///   - `ConcurrencyLimitedDispatcher`
-///   - `DispatchQueueDispatcher`
-///   - `CurrentThreadDispatcher`
 
 public protocol Dispatcher {
     func dispatch(_ body: @escaping () -> Void)
@@ -419,7 +412,7 @@ public extension CatchMixin {
      - Parameter policy: The default policy does not execute your handler for cancellation errors.
      - Parameter execute: The handler to execute if this promise is rejected.
      - Returns: A promise finalizer.
-     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation/docs/)
+     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation/docs/)
      */
     @discardableResult
     func `catch`(on: DispatchQueue? = .pmkDefault, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) -> Void) -> PMKFinalizer {
@@ -442,7 +435,7 @@ public extension CatchMixin {
      
      - Parameter on: The queue to which the provided closure dispatches.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation/docs/)
+     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation/docs/)
      */
     func recover<U: Thenable>(on: DispatchQueue? = .pmkDefault, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) throws -> U) -> Promise<T> where U.T == T {
         let dispatcher = selectDispatcher(given: on, configured: conf.D.map, flags: flags)
@@ -455,7 +448,7 @@ public extension CatchMixin {
      - Note it is logically impossible for this to take a `catchPolicy`, thus `allErrors` are handled.
      - Parameter on: The queue to which the provided closure dispatches.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation/docs/)
+     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation/docs/)
      */
     @discardableResult
     func recover(on: DispatchQueue? = .pmkDefault, flags: DispatchWorkItemFlags? = nil, _ body: @escaping(Error) -> Guarantee<T>) -> Guarantee<T> {
@@ -526,7 +519,7 @@ public extension CatchMixin where T == Void {
      
      - Parameter on: The queue to which the provided closure dispatches.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation/docs/)
+     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation/docs/)
      */
     @discardableResult
     func recover(on: DispatchQueue? = .pmkDefault, flags: DispatchWorkItemFlags? = nil, _ body: @escaping(Error) -> Void) -> Guarantee<Void> {
@@ -541,7 +534,7 @@ public extension CatchMixin where T == Void {
      
      - Parameter on: The queue to which the provided closure dispatches.
      - Parameter body: The handler to execute if this promise is rejected.
-     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documentation/CommonPatterns.md#cancellation/docs/)
+     - SeeAlso: [Cancellation](http://https://github.com/mxcl/PromiseKit/blob/master/Documents/CommonPatterns.md#cancellation/docs/)
      */
     func recover(on: DispatchQueue? = .pmkDefault, flags: DispatchWorkItemFlags? = nil, policy: CatchPolicy = conf.catchPolicy, _ body: @escaping(Error) throws -> Void) -> Promise<Void> {
         let dispatcher = selectDispatcher(given: on, configured: conf.D.map, flags: flags)

--- a/Sources/Dispatcher.swift
+++ b/Sources/Dispatcher.swift
@@ -21,22 +21,28 @@ public protocol Dispatcher {
     func dispatch(_ body: @escaping () -> Void)
 }
 
-/// A `Dispatcher` class that bundles a `DispatchQueue` with
-/// a set of `DispatchWorkItemFlags`. Closures dispatched
-/// through this `Dispatcher` will use the specified flags.
+/// A `Dispatcher` that bundles a `DispatchQueue` with
+/// a `DispatchGroup`, a set of `DispatchWorkItemFlags`, and a
+/// quality-of-service level. Closures dispatched through this
+/// `Dispatcher` will be submitted to the underlying `DispatchQueue`
+/// with the supplied components.
 
 public struct DispatchQueueDispatcher: Dispatcher {
     
     let queue: DispatchQueue
+    let group: DispatchGroup?
+    let qos: DispatchQoS
     let flags: DispatchWorkItemFlags
     
-    init(queue: DispatchQueue, flags: DispatchWorkItemFlags) {
+    init(queue: DispatchQueue, group: DispatchGroup? = nil, qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = []) {
         self.queue = queue
+        self.group = group
+        self.qos = qos
         self.flags = flags
     }
 
     public func dispatch(_ body: @escaping () -> Void) {
-        queue.async(flags: flags, execute: body)
+        queue.async(group: group, qos: qos, flags: flags, execute: body)
     }
 
 }

--- a/Sources/Dispatcher.swift
+++ b/Sources/Dispatcher.swift
@@ -74,7 +74,7 @@ public extension DispatchQueue {
 /// variables.)
 
 public struct CurrentThreadDispatcher: Dispatcher {
-    public func dispatch(_ body: @escaping () -> Void) {
+    public func dispatch(_ body: () -> Void) {
         body()
     }
 }

--- a/Sources/Guarantee.swift
+++ b/Sources/Guarantee.swift
@@ -201,9 +201,9 @@ public extension DispatchQueue {
      - Returns: A new `Guarantee` resolved by the result of the provided closure.
      */
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
-    final func async<T>(_: PMKNamespacer, group: DispatchGroup? = nil, qos: DispatchQoS = .default, flags: DispatchWorkItemFlags = [], execute body: @escaping () -> T) -> Guarantee<T> {
+    final func async<T>(_: PMKNamespacer, group: DispatchGroup? = nil, qos: DispatchQoS? = nil, flags: DispatchWorkItemFlags? = nil, execute body: @escaping () -> T) -> Guarantee<T> {
         let rg = Guarantee<T>(.pending)
-        async(group: group, qos: qos, flags: flags) {
+        asyncD(group: group, qos: qos, flags: flags) {
             rg.box.seal(body())
         }
         return rg

--- a/Sources/Guarantee.swift
+++ b/Sources/Guarantee.swift
@@ -185,7 +185,7 @@ public extension Guarantee where T == Void {
 
 public extension DispatchQueue {
     /**
-     Asynchronously executes the provided closure on a dispatch queue.
+     Asynchronously executes the provided closure on a dispatch queue, yielding a `Guarantee`.
 
          DispatchQueue.global().async(.promise) {
              md5(input)
@@ -193,9 +193,12 @@ public extension DispatchQueue {
              //…
          }
 
-     - Parameter body: The closure that resolves this promise.
+     - _: Must be `.promise` to distinguish from standard `DispatchQueue.async`
+     - group: A `DispatchGroup`, as for standard `DispatchQueue.async`
+     - qos: A quality-of-service grade, as for standard `DispatchQueue.async`
+     - flags: Work item flags, as for standard `DispatchQueue.async`
+     - body: A closure that yields a value to resolve the guarantee.
      - Returns: A new `Guarantee` resolved by the result of the provided closure.
-     - Note: There is no Promise/Thenable version of this due to Swift compiler ambiguity issues.
      */
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
     final func async<T>(_: PMKNamespacer, group: DispatchGroup? = nil, qos: DispatchQoS = .default, flags: DispatchWorkItemFlags = [], execute body: @escaping () -> T) -> Guarantee<T> {
@@ -209,17 +212,17 @@ public extension DispatchQueue {
 
 public extension Dispatcher {
     /**
-     Executes the provided value-returning closure on a Dispatcher, yielding a Guarantee.
-     
-         dispatcher.guarantee {
+     Executes the provided closure on a `Dispatcher`, yielding a `Guarantee`
+     that represents the value ultimately returned by the closure.
+
+         dispatcher.dispatch {
             md5(input)
          }.done { md5 in
             //…
          }
      
-     - Parameter body: The closure that resolves this promise.
+     - Parameter body: The closure that yields the value of the Guarantee.
      - Returns: A new `Guarantee` resolved by the result of the provided closure.
-     - Note: There is no Promise/Thenable version of this due to Swift compiler ambiguity issues.
      */
     func dispatch<T>(_ body: @escaping () -> T) -> Guarantee<T> {
         let rg = Guarantee<T>(.pending)

--- a/Sources/Guarantee.swift
+++ b/Sources/Guarantee.swift
@@ -209,7 +209,7 @@ public extension DispatchQueue {
 
 public extension Dispatcher {
     /**
-     Asynchronously executes the provided closure on a Dispatcher.
+     Executes the provided value-returning closure on a Dispatcher, yielding a Guarantee.
      
          dispatcher.guarantee {
             md5(input)
@@ -221,7 +221,7 @@ public extension Dispatcher {
      - Returns: A new `Guarantee` resolved by the result of the provided closure.
      - Note: There is no Promise/Thenable version of this due to Swift compiler ambiguity issues.
      */
-    func dispatch<T>(_: PMKNamespacer, _ body: @escaping () -> T) -> Guarantee<T> {
+    func dispatch<T>(_ body: @escaping () -> T) -> Guarantee<T> {
         let rg = Guarantee<T>(.pending)
         dispatch {
             rg.box.seal(body())

--- a/Sources/LogEvent.swift
+++ b/Sources/LogEvent.swift
@@ -27,4 +27,29 @@ public enum LogEvent {
     
     /// An error which occurred while resolving a promise was swallowed
     case cauterized(Error)
+    
+    /// Odd arguments to DispatchQueue-compatibility layer
+    case nilDispatchQueueWithFlags
+    
+    /// DispatchWorkItem flags specified for non-DispatchQueue Dispatcher
+    case extraneousFlagsSpecified
+    
+    public func asString() -> String {
+        var message: String
+        switch self {
+            case .waitOnMainThread:
+                message = " warning: `wait()` called on main thread!"
+            case .pendingPromiseDeallocated:
+                message = " warning: pending promise deallocated"
+            case .pendingGuaranteeDeallocated:
+                message = " warning: pending guarantee deallocated"
+            case .cauterized(let error):
+                message = "cauterized-error: \(error)"
+            case .nilDispatchQueueWithFlags:
+                message = " warning: nil DispatchQueue specified, but DispatchWorkItemFlags were also supplied (ignored)"
+            case .extraneousFlagsSpecified:
+                message = " warning: DispatchWorkItemFlags flags specified, but default Dispatcher is not a DispatchQueue (ignored)"
+        }
+        return "PromiseKit:\(message)"
+    }
 }

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -151,9 +151,9 @@ public extension DispatchQueue {
      - Returns: A new `Promise` resolved by the result of the provided closure.
      */
     @available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
-    final func async<T>(_: PMKNamespacer, group: DispatchGroup? = nil, qos: DispatchQoS = .default, flags: DispatchWorkItemFlags = [], execute body: @escaping () throws -> T) -> Promise<T> {
+    final func async<T>(_: PMKNamespacer, group: DispatchGroup? = nil, qos: DispatchQoS? = nil, flags: DispatchWorkItemFlags? = nil, execute body: @escaping () throws -> T) -> Promise<T> {
         let promise = Promise<T>(.pending)
-        async(group: group, qos: qos, flags: flags) {
+        asyncD(group: group, qos: qos, flags: flags) {
             do {
                 promise.box.seal(.success(try body()))
             } catch {

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -134,7 +134,7 @@ extension Promise where T == Void {
 
 public extension DispatchQueue {
     /**
-     Asynchronously executes the provided closure on a dispatch queue.
+     Asynchronously executes the provided closure on a dispatch queue, yielding a `Promise`.
 
          DispatchQueue.global().async(.promise) {
              try md5(input)
@@ -142,9 +142,13 @@ public extension DispatchQueue {
              //…
          }
 
-     - Parameter body: The closure that resolves this promise.
+     - Parameters:
+       - _: Must be `.promise` to distinguish from standard `DispatchQueue.async`
+       - group: A `DispatchGroup`, as for standard `DispatchQueue.async`
+       - qos: A quality-of-service grade, as for standard `DispatchQueue.async`
+       - flags: Work item flags, as for standard `DispatchQueue.async`
+       - body: A closure that yields a value to resolve the promise.
      - Returns: A new `Promise` resolved by the result of the provided closure.
-     - Note: There is no Promise/Thenable version of this due to Swift compiler ambiguity issues.
      */
     @available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
     final func async<T>(_: PMKNamespacer, group: DispatchGroup? = nil, qos: DispatchQoS = .default, flags: DispatchWorkItemFlags = [], execute body: @escaping () throws -> T) -> Promise<T> {
@@ -162,17 +166,17 @@ public extension DispatchQueue {
 
 public extension Dispatcher {
     /**
-     Executes the provided value-returning closure on a Dispatcher, yielding a Promise.
+     Executes the provided closure on a `Dispatcher`, yielding a `Promise`
+     that represents the value ultimately returned by the closure.
      
-         dispatcher.promise {
+         dispatcher.dispatch {
             try md5(input)
          }.done { md5 in
             //…
          }
      
-     - Parameter body: The closure that resolves this promise.
+     - Parameter body: A closure that yields a value to resolve the promise.
      - Returns: A new `Promise` resolved by the result of the provided closure.
-     - Note: There is no Promise/Thenable version of this due to Swift compiler ambiguity issues.
      */
     func dispatch<T>(_ body: @escaping () throws -> T) -> Promise<T> {
         let promise = Promise<T>(.pending)

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -162,7 +162,7 @@ public extension DispatchQueue {
 
 public extension Dispatcher {
     /**
-     Asynchronously executes the provided closure on a Dispatcher.
+     Executes the provided value-returning closure on a Dispatcher, yielding a Promise.
      
          dispatcher.promise {
             try md5(input)
@@ -174,7 +174,7 @@ public extension Dispatcher {
      - Returns: A new `Promise` resolved by the result of the provided closure.
      - Note: There is no Promise/Thenable version of this due to Swift compiler ambiguity issues.
      */
-    func dispatch<T>(_: PMKNamespacer, _ body: @escaping () throws -> T) -> Promise<T> {
+    func dispatch<T>(_ body: @escaping () throws -> T) -> Promise<T> {
         let promise = Promise<T>(.pending)
         dispatch {
             do {

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -109,7 +109,7 @@ public extension Promise {
     func wait() throws -> T {
 
         if Thread.isMainThread {
-            conf.logHandler(LogEvent.waitOnMainThread)
+            conf.logHandler(.waitOnMainThread)
         }
 
         var result = self.result

--- a/Tests/Core/DispatcherTests.swift
+++ b/Tests/Core/DispatcherTests.swift
@@ -59,6 +59,11 @@ class DispatcherTests: XCTestCase {
         PromiseKit.conf.D = oldConf
     }
     
+    func testPMKDefaultIdentity() {
+        // If this identity does not hold, the DispatchQueue wrapper API will not behave correctly
+        XCTAssert(DispatchQueue.pmkDefault === DispatchQueue.pmkDefault, "DispatchQueues are not object-identity-preserving on this platform")
+    }
+    
     func testDispatcherWithThrow() {
         let ex = expectation(description: "Dispatcher with throw")
         Promise { seal in

--- a/Tests/Core/DispatcherTests.swift
+++ b/Tests/Core/DispatcherTests.swift
@@ -127,10 +127,12 @@ class DispatcherTests: XCTestCase {
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
     func testDispatcherExtensionReturnsGuarantee() {
         let ex = expectation(description: "Dispatcher.promise")
-        dispatcher.dispatch() { () -> Int in
+        let object: Any = dispatcher.dispatch() { () -> Int in
             XCTAssertFalse(Thread.isMainThread)
             return 1
-        }.done { one in
+        }
+        XCTAssert(object is Guarantee<Int>, "Guarantee not returned from Dispatcher.dispatch { () -> Int }")
+        (object as? Guarantee<Int>)?.done { one in
             XCTAssertEqual(one, 1)
             ex.fulfill()
         }
@@ -140,9 +142,11 @@ class DispatcherTests: XCTestCase {
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
     func testDispatcherExtensionCanThrowInBody() {
         let ex = expectation(description: "Dispatcher.promise")
-        dispatcher.dispatch() { () -> Int in
+        let object: Any = dispatcher.dispatch() { () -> Int in
             throw PMKError.badInput
-        }.done { _ in
+        }
+        XCTAssert(object is Promise<Int>, "Promise not returned from Dispatcher.dispatch { () throws -> Int }")
+        (object as? Promise<Int>)?.done { _ in
             XCTFail()
         }.catch { _ in
             ex.fulfill()

--- a/Tests/Core/DispatcherTests.swift
+++ b/Tests/Core/DispatcherTests.swift
@@ -122,7 +122,7 @@ class DispatcherTests: XCTestCase {
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
     func testDispatcherExtensionReturnsGuarantee() {
         let ex = expectation(description: "Dispatcher.promise")
-        dispatcher.dispatch(.promise) { () -> Int in
+        dispatcher.dispatch() { () -> Int in
             XCTAssertFalse(Thread.isMainThread)
             return 1
         }.done { one in
@@ -135,7 +135,7 @@ class DispatcherTests: XCTestCase {
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
     func testDispatcherExtensionCanThrowInBody() {
         let ex = expectation(description: "Dispatcher.promise")
-        dispatcher.dispatch(.promise) { () -> Int in
+        dispatcher.dispatch() { () -> Int in
             throw PMKError.badInput
         }.done { _ in
             XCTFail()

--- a/Tests/Core/PromiseTests.swift
+++ b/Tests/Core/PromiseTests.swift
@@ -28,32 +28,104 @@ class PromiseTests: XCTestCase {
     }
 
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
-    func testDispatchQueueAsyncExtensionReturnsPromise() {
+    func testDispatchQueueAsyncExtensionReturnsGuarantee() {
         let ex = expectation(description: "")
-
-        DispatchQueue.global().async(.promise) { () -> Int in
+        let returnedValue: Any = DispatchQueue.global().async(.promise) { () -> Int in
             XCTAssertFalse(Thread.isMainThread)
             return 1
-        }.done { one in
-            XCTAssertEqual(one, 1)
-            ex.fulfill()
         }
+        // This is statically determined, but we want to promote it into something that fits into XCTest
+        XCTAssert(returnedValue is Guarantee<Int>, "DispatchQueue.async() returns non-Guarantee even when code doesn't throw")
+        if let guarantee = returnedValue as? Guarantee<Int> {
+            guarantee.done { one in
+                XCTAssertEqual(one, 1)
+                ex.fulfill()
+            }
+            waitForExpectations(timeout: 1)
+       }
+    }
 
-        waitForExpectations(timeout: 1)
+    @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
+    func testDispatcherDispatchExtensionReturnsGuarantee() {
+        let ex = expectation(description: "Dispatcher.dispatch -> Guarantee")
+        let dispatcher: Dispatcher = DispatchQueue.global()
+        let returnedValue: Any = dispatcher.dispatch { () -> Int in
+            XCTAssertFalse(Thread.isMainThread)
+            return 1
+        }
+        // This is statically determined, but we want to promote it into something that fits into XCTest
+        XCTAssert(returnedValue is Guarantee<Int>, "Dispatcher.dispatch() returns non-Guarantee even when code doesn't throw")
+        if let guarantee = returnedValue as? Guarantee<Int> {
+            guarantee.done { one in
+                XCTAssertEqual(one, 1)
+                ex.fulfill()
+            }
+            waitForExpectations(timeout: 1)
+        }
     }
 
     @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
     func testDispatchQueueAsyncExtensionCanThrowInBody() {
         let ex = expectation(description: "")
-
-        DispatchQueue.global().async(.promise) { () -> Int in
+        let returnedValue: Any = DispatchQueue.global().async(.promise) { () -> Int in
             throw Error.dummy
-        }.done { _ in
-            XCTFail()
-        }.catch { _ in
-            ex.fulfill()
         }
+        // This is statically determined, but we want to promote it into something that fits into XCTest
+        XCTAssert(returnedValue is Promise<Int>, "Dispatcher.dispatch() returns non-Promise even when code can throw")
+        XCTAssert(returnedValue is Promise<Int>, "DispatchQueue.async() returns non-Promise even when code can throw")
+       if let promise = returnedValue as? Promise<Int> {
+            promise.done { _ in
+                XCTFail("Promise should not complete normally")
+            }.catch { _ in
+                ex.fulfill()
+            }
+            waitForExpectations(timeout: 1)
+        } else {
+            XCTFail("Could not recover Promise<Int> from Any")
+        }
+    }
 
+    @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
+    func testDispatcherDispatchExtensionCanThrowInBody() {
+        let ex = expectation(description: "Dispatcher.dispatch -> Promise")
+        let dispatcher: Dispatcher = DispatchQueue.global()
+        let returnedValue: Any = dispatcher.dispatch { () -> Int in
+            throw Error.dummy
+        }
+        // This is statically determined, but we want to promote it into something that fits into XCTest
+        XCTAssert(returnedValue is Promise<Int>, "Dispatcher.dispatch() returns non-Promise even when code can throw")
+        if let promise = returnedValue as? Promise<Int> {
+            promise.done { _ in
+                XCTFail("Promise should not complete normally")
+                }.catch { _ in
+                    ex.fulfill()
+            }
+            waitForExpectations(timeout: 1)
+        } else {
+            XCTFail("Could not recover Promise<Int> from Any")
+        }
+    }
+
+    @available(macOS 10.10, iOS 2.0, tvOS 10.0, watchOS 2.0, *)
+    func testDispatcherDispatchExtensionDoesNotInterfereWithRegularDispatch() {
+        let dispatcher: Dispatcher = DispatchQueue.global()
+        
+        let plain = expectation(description: "plain closure")
+        let plainReturn: Any = dispatcher.dispatch {
+            plain.fulfill()
+        }
+        // This is statically determined, but we want to promote it into something that fits into XCTest
+        XCTAssert(plainReturn is Void, "Dispatcher.dispatch() returns something other than Void")
+        
+        // With a throwing closure, the return should be a Promise, even without a return value.
+        // There's no standard Dispatcher API that accepts throwing closures for dispatch.
+        let throwing = expectation(description: "throwing closure")
+        let throwingReturn: Any = dispatcher.dispatch {
+            throwing.fulfill()
+            throw Error.dummy
+        }
+        // This is statically determined, but we want to promote it into something that fits into XCTest
+        XCTAssert(throwingReturn is Promise<Void>, "Dispatcher.dispatch() returns something other than Promise<Void> with plain throwing closure")
         waitForExpectations(timeout: 1)
     }
 

--- a/Tests/Core/XCTestManifests.swift
+++ b/Tests/Core/XCTestManifests.swift
@@ -60,6 +60,7 @@ extension DispatcherTests {
         ("testDispatcherExtensionReturnsGuarantee", testDispatcherExtensionReturnsGuarantee),
         ("testDispatcherWithThrow", testDispatcherWithThrow),
         ("testDispatchQueueSelection", testDispatchQueueSelection),
+        ("testPMKDefaultIdentity", testPMKDefaultIdentity),
     ]
 }
 
@@ -100,8 +101,10 @@ extension LoggingTests {
     // to regenerate.
     static let __allTests__LoggingTests = [
         ("testCauterizeIsLogged", testCauterizeIsLogged),
+        ("testExtraneousFlagsSpecified", testExtraneousFlagsSpecified),
         ("testGuaranteeWaitOnMainThreadLogged", testGuaranteeWaitOnMainThreadLogged),
         ("testLogging", testLogging),
+        ("testNilDispatchQueueWithFlags", testNilDispatchQueueWithFlags),
         ("testPendingGuaranteeDeallocatedIsLogged", testPendingGuaranteeDeallocatedIsLogged),
         ("testPendingPromiseDeallocatedIsLogged", testPendingPromiseDeallocatedIsLogged),
         ("testPromiseWaitOnMainThreadLogged", testPromiseWaitOnMainThreadLogged),
@@ -137,8 +140,11 @@ extension PromiseTests {
         ("testCanMakeVoidPromise", testCanMakeVoidPromise),
         ("testCannotFulfillWithError", testCannotFulfillWithError),
         ("testCustomStringConvertible", testCustomStringConvertible),
+        ("testDispatcherDispatchExtensionCanThrowInBody", testDispatcherDispatchExtensionCanThrowInBody),
+        ("testDispatcherDispatchExtensionDoesNotInterfereWithRegularDispatch", testDispatcherDispatchExtensionDoesNotInterfereWithRegularDispatch),
+        ("testDispatcherDispatchExtensionReturnsGuarantee", testDispatcherDispatchExtensionReturnsGuarantee),
         ("testDispatchQueueAsyncExtensionCanThrowInBody", testDispatchQueueAsyncExtensionCanThrowInBody),
-        ("testDispatchQueueAsyncExtensionReturnsPromise", testDispatchQueueAsyncExtensionReturnsPromise),
+        ("testDispatchQueueAsyncExtensionReturnsGuarantee", testDispatchQueueAsyncExtensionReturnsGuarantee),
         ("testIsFulfilled", testIsFulfilled),
         ("testIsPending", testIsPending),
         ("testIsRejected", testIsRejected),


### PR DESCRIPTION
This should be ready to go. Main changes:

* Adds documentation. It seemed best to keep most existing docs and examples in terms of `conf.Q` and `DispatchQueue` since most people will never need to concern themselves with dispatchers. I just wanted to leave some breadcrumbs for people who are looking, so there's a blurb in the `Appendix` that describes `Dispatcher` in a bit more detail. There are a few other incidental doc changes as well, mostly about versioning.

* Inline documentation groomed and tested.

* `DispatchQueueDispatcher` can now accommodate a `DispatchGroup` and QoS in addition to work item flags. These aren't used internally; they're just there for completeness in case someone wants them. Also, added some code to make sure nothing in PromiseKit ever presumes to know what the default QoS or flags are. 

* `Dispatcher.dispatch()` with a value-returning closure no longer requires a `.promise` namespacer. It returns a Promise or Guarantee, as appropriate. There are tests to look for possible ambiguities, but it seems to work fine. (Of course, it doesn't work if the value is Void since that's the only thing that distinguishes actual dispatch requests from promise-creating shorthand.)

* The code now conforms to the existing PromiseKit logging/error reporting scheme. I moved stringification into the `LogError` enum so that users can access it easily even if they write their own error handlers.

* Travis set to build any v7* branch rather than just "v7". You can drop this one commit if you don't want that part.
