### PR TITLE
'Cancel' for PromiseKit: fix for #1026, plus cleanup

### DIFF
--- a/Sources/CancellablePromise.swift
+++ b/Sources/CancellablePromise.swift
@@ -127,7 +127,6 @@ public class CancellablePromise<T>: CancellableThenable, CancellableCatchMixin {
     }
 }
 
-#if swift(>=3.1)
 extension CancellablePromise where T == Void {
     /// Initializes a new cancellable promise fulfilled with `Void`
     public convenience init() {
@@ -140,4 +139,3 @@ extension CancellablePromise where T == Void {
         self.appendCancellable(cancellable, reject: nil)
     }
 }
-#endif

--- a/Tests/Cancel/CancelChain.swift
+++ b/Tests/Cancel/CancelChain.swift
@@ -153,11 +153,7 @@ class CancelChain: XCTestCase {
         
             self.trace("SETUP COMPLETE")
             
-#if swift(>=4.1)
             let expectations = [ex.a, ex.b, ex.c, ex.d, ex.e, ex.cancelled].compactMap { $0 }
-#else
-            let expectations = [ex.a, ex.b, ex.c, ex.d, ex.e, ex.cancelled].flatMap { $0 }
-#endif
             wait(for: expectations, timeout: 1)
             
             XCTAssert(c.pA.cancelContext.cancelAttempted)

--- a/Tests/Cancel/CancellableErrorTests.swift
+++ b/Tests/Cancel/CancellableErrorTests.swift
@@ -101,14 +101,12 @@ class CancellationTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-#if swift(>=3.2)
     func testIsCancelled() {
         XCTAssertTrue(PMKError.cancelled.isCancelled)
         XCTAssertTrue(URLError.cancelled.isCancelled)
         XCTAssertTrue(CocoaError.cancelled.isCancelled)
         XCTAssertFalse(CocoaError(_nsError: NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.coderInvalidValue.rawValue)).isCancelled)
     }
-#endif
 }
 
 private enum LocalError: CancellableError {

--- a/Tests/Cancel/DispatcherTests.swift
+++ b/Tests/Cancel/DispatcherTests.swift
@@ -109,8 +109,8 @@ class DispatcherTests: XCTestCase {
             Promise.value(v + 10).cancellize()
         }.thenMap(on: .global(qos: .background), flags: .barrier) { v -> Promise<Int> in
             Promise.value(v + 10)
-        }.thenFlatMap(on: .global(qos: .background), flags: .barrier) {
-            Promise.value([$0 + 10]).cancellize()
+        }.thenFlatMap(on: .global(qos: .background), flags: .barrier) { v -> CancellablePromise<[Int]> in
+            Promise.value([v + 10]).cancellize()
         }.thenFlatMap(on: .global(qos: .background), flags: .barrier) { v -> Promise<[Int]> in
             Promise.value([v + 10])
         }.filterValues(on: .global(qos: .background), flags: .barrier) { _ in

--- a/Tests/Cancel/GuaranteeTests.swift
+++ b/Tests/Cancel/GuaranteeTests.swift
@@ -43,18 +43,10 @@ class GuaranteeTests: XCTestCase {
     }
     
     func testCancellable() {
-#if swift(>=4.0)
         var resolver: ((()) -> Void)!
-#else
-        var resolver: ((Void) -> Void)!
-#endif
 
         let task = DispatchWorkItem {
-#if swift(>=4.0)
             resolver(())
-#else
-            resolver()
-#endif
         }
         
         q.asyncAfter(deadline: DispatchTime.now() + 0.5, execute: task)
@@ -76,18 +68,10 @@ class GuaranteeTests: XCTestCase {
     }
 
     func testSetCancellable() {
-#if swift(>=4.0)
         var resolver: ((()) -> Void)!
-#else
-        var resolver: ((Void) -> Void)!
-#endif
 
         let task = DispatchWorkItem {
-#if swift(>=4.0)
             resolver(())
-#else
-            resolver()
-#endif
         }
         
         q.asyncAfter(deadline: DispatchTime.now() + 0.5, execute: task)

--- a/Tests/Cancel/PromiseTests.swift
+++ b/Tests/Cancel/PromiseTests.swift
@@ -86,12 +86,10 @@ class PromiseTests: XCTestCase {
         _ = CancellablePromise().map { Error.dummy }
     }
 
-#if swift(>=3.1)
     func testCanMakeVoidPromise() {
         _ = CancellablePromise()
         _ = Guarantee()
     }
-#endif
 
     enum Error: Swift.Error {
         case dummy
@@ -154,11 +152,7 @@ class PromiseTests: XCTestCase {
         var resolver: Resolver<Void>!
 
         let task = DispatchWorkItem {
-#if swift(>=4.0)
             resolver.fulfill(())
-#else
-            resolver.fulfill()
-#endif
         }
         
         q.asyncAfter(deadline: DispatchTime.now() + 0.5, execute: task)
@@ -183,11 +177,7 @@ class PromiseTests: XCTestCase {
         var resolver: Resolver<Void>!
 
         let task = DispatchWorkItem {
-#if swift(>=4.0)
             resolver.fulfill(())
-#else
-            resolver.fulfill()
-#endif
         }
         
         q.asyncAfter(deadline: DispatchTime.now() + 0.5, execute: task)
@@ -215,11 +205,7 @@ class PromiseTests: XCTestCase {
         var resolver: Resolver<Void>!
 
         let task = DispatchWorkItem {
-#if swift(>=4.0)
             resolver.fulfill(())
-#else
-            resolver.fulfill()
-#endif
         }
         
         q.asyncAfter(deadline: DispatchTime.now() + 0.5, execute: task)

--- a/Tests/Cancel/ResolverTests.swift
+++ b/Tests/Cancel/ResolverTests.swift
@@ -244,7 +244,6 @@ class WrapTests: XCTestCase {
         wait(for: [ex1, ex2] ,timeout: 1)
     }
 
-#if swift(>=3.1)
     func testVoidCompletionValue() {
         let ex1 = expectation(description: "")
         let kf1 = KittenFetcher(value: nil, error: nil)
@@ -284,7 +283,6 @@ class WrapTests: XCTestCase {
 
         wait(for: [ex1, ex2], timeout: 1)
     }
-#endif
 
     func testIsFulfilled() {
         let p1 = Promise.value(()).cancellize()


### PR DESCRIPTION
* Fix "Typechecking timeout compiling tests in v7 #1026" by specifying the closure return type in DispatcherTests
* Remove unnecessary "#if swift" checks in the cancellable code and tests