### PR TITLE
CancellablePromise bridge initializer should run 'catch' on CurrentThreadDispatcher()

### DIFF
--- a/Sources/Cancellation/CancellablePromise.swift
+++ b/Sources/Cancellation/CancellablePromise.swift
@@ -74,7 +74,7 @@ public class CancellablePromise<T>: CancellableThenable, CancellableCatchMixin {
                 reject = seal.reject
                 bridge.done(on: CurrentThreadDispatcher()) {
                     seal.fulfill($0)
-                }.catch(policy: .allErrors) {
+                }.catch(on: CurrentThreadDispatcher(), policy: .allErrors) {
                     seal.reject($0)
                 }
             }

--- a/Tests/Cancel/CatchableTests.swift
+++ b/Tests/Cancel/CatchableTests.swift
@@ -749,7 +749,7 @@ extension CatchableTests {
             return promise
         }
         promise.catch(policy: .allErrors) { err in
-            err.isCancelled ? x.fulfill() : XCTFail()
+            err.isCancelled ? XCTFail() : x.fulfill()
         }
         promise.cancel()
 

--- a/Tests/Cancel/ThenableTests.swift
+++ b/Tests/Cancel/ThenableTests.swift
@@ -131,7 +131,7 @@ class ThenableTests: XCTestCase {
             XCTFail()
             return .value(x)
         }.catch(policy: .allErrors) {
-            $0.isCancelled ? ex.fulfill() : XCTFail()
+            $0.isCancelled ? XCTFail() : ex.fulfill()
         }.cancel()
         wait(for: [ex], timeout: 1)
     }

--- a/Tests/Cancel/WhenConcurrentTests.swift
+++ b/Tests/Cancel/WhenConcurrentTests.swift
@@ -267,7 +267,7 @@ class WhenConcurrentTestCase_Swift: XCTestCase {
         when(fulfilled: generator, concurrently: 1).done {
             XCTFail("\($0)")
         }.catch(policy: .allErrors) {
-            $0.isCancelled ? ex.fulfill() : XCTFail()
+            $0.isCancelled ? XCTFail() : ex.fulfill()
         }.cancel()
 
         waitForExpectations(timeout: 3)

--- a/Tests/Cancel/WhenTests.swift
+++ b/Tests/Cancel/WhenTests.swift
@@ -279,7 +279,7 @@ class WhenTests: XCTestCase {
         let p1 = CancellablePromise<Int>(error: Error.test)
         let p2 = after(.milliseconds(100)).cancellize()
         cancellableWhen(fulfilled: p1, p2).done{ _ in XCTFail() }.catch(policy: .allErrors) {
-            $0.isCancelled ? ex.fulfill() : XCTFail()
+            $0.isCancelled ? XCTFail() : ex.fulfill()
         }.cancel()
 
         waitForExpectations(timeout: 1, handler: nil)
@@ -300,7 +300,7 @@ class WhenTests: XCTestCase {
         let p3 = after(.milliseconds(200)).cancellize().done { throw Error.straggler }
 
         cancellableWhen(fulfilled: p1, p2, p3).catch(policy: .allErrors) {
-            $0.isCancelled ? ex1.fulfill() : XCTFail()
+            $0.isCancelled ? XCTFail() : ex1.fulfill()
         }.cancel()
 
         p2.ensure { after(.milliseconds(100)).done(ex2.fulfill) }.silenceWarning()
@@ -322,7 +322,7 @@ class WhenTests: XCTestCase {
         let p3 = CancellablePromise<Void>(error: Error.test3)
 
         when(fulfilled: p1, p2, p3).catch(policy: .allErrors) {
-            $0.isCancelled ? ex.fulfill() : XCTFail()
+            $0.isCancelled ? XCTFail() : ex.fulfill()
         }.cancel()
 
         waitForExpectations(timeout: 1)


### PR DESCRIPTION
Fix for #1049: "Some tests seem to depend on dispatching that PromiseKit should perhaps not be doing"

Yup, CancellablePromise is definitely doing some dispatching that it shouldn't be doing.  Fixed exactly as Garth suggests, by having the CancellablePromise bridge initializer run 'catch' on CurrentThreadDispatcher().

Also updating 6 affected tests for this change.
