### PR TITLE
Add AnyPromise.wait

### DIFF
--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -183,6 +183,13 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
 - (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, dispatch_block_t __nonnull))ensureOn NS_REFINED_FOR_SWIFT;
 
 /**
+ Wait until the promise is resolved.
+
+ @return Value if fulfilled or error if rejected.
+ */
+- (id __nullable)wait NS_REFINED_FOR_SWIFT;
+
+/**
  Create a new promise with an associated resolver.
 
  Use this method when wrapping asynchronous code that does *not* use

--- a/Sources/AnyPromise.m
+++ b/Sources/AnyPromise.m
@@ -112,6 +112,10 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
     };
 }
 
+- (id)wait {
+    return [d __wait];
+}
+
 - (BOOL)pending {
     return [[d valueForKey:@"__pending"] boolValue];
 }

--- a/Sources/AnyPromise.swift
+++ b/Sources/AnyPromise.swift
@@ -61,6 +61,26 @@ import Foundation
         }))
     }
 
+    @objc public func __wait() -> Any? {
+        if Thread.isMainThread {
+            conf.logHandler(.waitOnMainThread)
+        }
+        
+        var result = __value
+        
+        if result == nil {
+            let group = DispatchGroup()
+            group.enter()
+            self.__pipe { obj in
+                result = obj
+                group.leave()
+            }
+            group.wait()
+        }
+        
+        return result
+    }
+ 
     /// Internal, do not use! Some behaviors undefined.
     @objc public func __pipe(_ to: @escaping (Any?) -> Void) {
         let to = { (obj: Any?) -> Void in

--- a/Tests/CoreObjC/AnyPromiseTests.m
+++ b/Tests/CoreObjC/AnyPromiseTests.m
@@ -757,28 +757,20 @@ static inline AnyPromise *fulfillLater() {
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)test_61_wait_for_value {
-    id ex1 = [self expectationWithDescription:@""];
-    
+- (void)test_61_wait_for_value {    
     id o = [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         resolve(@1);
     }].wait;
     
     XCTAssertEqualObjects(o, @1);
-    [ex1 fulfill];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)test_62_wait_for_error {
-    id ex1 = [self expectationWithDescription:@""];
-    
     NSError* err = [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         resolve([NSError errorWithDomain:@"a" code:123 userInfo:nil]);
     }].wait;
     
     XCTAssertEqual(err.code, 123);
-    [ex1 fulfill];
-    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)test_properties {

--- a/Tests/CoreObjC/AnyPromiseTests.m
+++ b/Tests/CoreObjC/AnyPromiseTests.m
@@ -757,6 +757,30 @@ static inline AnyPromise *fulfillLater() {
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)test_61_wait_for_value {
+    id ex1 = [self expectationWithDescription:@""];
+    
+    id o = [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        resolve(@1);
+    }].wait;
+    
+    XCTAssertEqualObjects(o, @1);
+    [ex1 fulfill];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)test_62_wait_for_error {
+    id ex1 = [self expectationWithDescription:@""];
+    
+    NSError* err = [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        resolve([NSError errorWithDomain:@"a" code:123 userInfo:nil]);
+    }].wait;
+    
+    XCTAssertEqual(err.code, 123);
+    [ex1 fulfill];
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
 - (void)test_properties {
     XCTAssertEqualObjects([AnyPromise promiseWithValue:@1].value, @1);
     XCTAssertEqualObjects([[AnyPromise promiseWithValue:dummyWithCode(2)].value localizedDescription], @"2");


### PR DESCRIPTION
Hello.
Thank you for this library.
I found out that `AnyPromise` does not support `wait` (found this method both in `Promise` and `Guarantee`). In this pull request I added it to `AnyPromise`.
