### PR TITLE
Fixed possible "Ambiguous use of 'when(fulfilled:)'"

### DIFF
--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -67,36 +67,36 @@ private func _when<U: Thenable>(_ thenables: [U]) -> Promise<Void> {
  - SeeAlso: `when(resolved:)`
 */
 public func when<U: Thenable>(fulfilled thenables: [U]) -> Promise<[U.T]> {
-    return _when(thenables).map(on: nil) { thenables.map{ $0.value! } }
+    return _when(thenables).map(on: nil) { thenables.map { $0.value! } }
 }
 
 /// Wait for all promises in a set to fulfill.
-public func when<U: Thenable>(fulfilled promises: U...) -> Promise<Void> where U.T == Void {
-    return _when(promises)
+public func when<U: Thenable>(fulfilled thenables: U...) -> Promise<Void> where U.T == Void {
+    return _when(thenables)
 }
 
 /// Wait for all promises in a set to fulfill.
-public func when<U: Thenable>(fulfilled promises: [U]) -> Promise<Void> where U.T == Void {
-    return _when(promises)
+public func when<U: Thenable>(fulfilled thenables: [U]) -> Promise<Void> where U.T == Void {
+    return _when(thenables)
 }
 
 /// Wait for all promises in a set to fulfill.
-public func when<U: Thenable, V: Thenable>(fulfilled pu: U, _ pv: V) -> Promise<(U.T, V.T)> {
+public func when<U: Thenable, V: Thenable>(thenables pu: U, _ pv: V) -> Promise<(U.T, V.T)> {
     return _when([pu.asVoid(), pv.asVoid()]).map(on: nil) { (pu.value!, pv.value!) }
 }
 
 /// Wait for all promises in a set to fulfill.
-public func when<U: Thenable, V: Thenable, W: Thenable>(fulfilled pu: U, _ pv: V, _ pw: W) -> Promise<(U.T, V.T, W.T)> {
+public func when<U: Thenable, V: Thenable, W: Thenable>(thenables pu: U, _ pv: V, _ pw: W) -> Promise<(U.T, V.T, W.T)> {
     return _when([pu.asVoid(), pv.asVoid(), pw.asVoid()]).map(on: nil) { (pu.value!, pv.value!, pw.value!) }
 }
 
 /// Wait for all promises in a set to fulfill.
-public func when<U: Thenable, V: Thenable, W: Thenable, X: Thenable>(fulfilled pu: U, _ pv: V, _ pw: W, _ px: X) -> Promise<(U.T, V.T, W.T, X.T)> {
+public func when<U: Thenable, V: Thenable, W: Thenable, X: Thenable>(thenables pu: U, _ pv: V, _ pw: W, _ px: X) -> Promise<(U.T, V.T, W.T, X.T)> {
     return _when([pu.asVoid(), pv.asVoid(), pw.asVoid(), px.asVoid()]).map(on: nil) { (pu.value!, pv.value!, pw.value!, px.value!) }
 }
 
 /// Wait for all promises in a set to fulfill.
-public func when<U: Thenable, V: Thenable, W: Thenable, X: Thenable, Y: Thenable>(fulfilled pu: U, _ pv: V, _ pw: W, _ px: X, _ py: Y) -> Promise<(U.T, V.T, W.T, X.T, Y.T)> {
+public func when<U: Thenable, V: Thenable, W: Thenable, X: Thenable, Y: Thenable>(thenables pu: U, _ pv: V, _ pw: W, _ px: X, _ py: Y) -> Promise<(U.T, V.T, W.T, X.T, Y.T)> {
     return _when([pu.asVoid(), pv.asVoid(), pw.asVoid(), px.asVoid(), py.asVoid()]).map(on: nil) { (pu.value!, pv.value!, pw.value!, px.value!, py.value!) }
 }
 
@@ -171,9 +171,9 @@ public func when<It: IteratorProtocol>(fulfilled promiseIterator: It, concurrent
             barrier.sync {
                 if pendingPromises == 0 {
                   #if !swift(>=3.3) || (swift(>=4) && !swift(>=4.1))
-                    root.resolver.fulfill(promises.flatMap{ $0.value })
+                    root.resolver.fulfill(promises.flatMap { $0.value })
                   #else
-                    root.resolver.fulfill(promises.compactMap{ $0.value })
+                    root.resolver.fulfill(promises.compactMap { $0.value })
                   #endif
                 }
             }
@@ -199,7 +199,7 @@ public func when<It: IteratorProtocol>(fulfilled promiseIterator: It, concurrent
 
         dequeue()
     }
-        
+
     dequeue()
 
     return root.promise
@@ -243,7 +243,7 @@ public func when<T>(resolved promises: [Promise<T>]) -> Guarantee<[Result<T>]> {
             }
             barrier.sync {
                 if countdown == 0 {
-                    rg.box.seal(promises.map{ $0.result! })
+                    rg.box.seal(promises.map { $0.result! })
                 }
             }
         }
@@ -258,5 +258,5 @@ public func when(_ guarantees: Guarantee<Void>...) -> Guarantee<Void> {
 
 // Waits on all provided Guarantees.
 public func when(guarantees: [Guarantee<Void>]) -> Guarantee<Void> {
-    return when(fulfilled: guarantees).recover{ _ in }.asVoid()
+    return when(fulfilled: guarantees).recover { _ in }.asVoid()
 }

--- a/Tests/CorePromise/WhenTests.swift
+++ b/Tests/CorePromise/WhenTests.swift
@@ -41,7 +41,7 @@ class WhenTests: XCTestCase {
         let e1 = expectation(description: "")
         let p1 = Promise.value(1)
         let p2 = Promise.value("abc")
-        when(fulfilled: p1, p2).done{ x, y in
+        when(thenables: p1, p2).done { x, y in
             XCTAssertEqual(x, 1)
             XCTAssertEqual(y, "abc")
             e1.fulfill()
@@ -54,7 +54,7 @@ class WhenTests: XCTestCase {
         let p1 = Promise.value(1)
         let p2 = Promise.value("abc")
         let p3 = Promise.value(     1.0)
-        when(fulfilled: p1, p2, p3).done { u, v, w in
+        when(thenables: p1, p2, p3).done { u, v, w in
             XCTAssertEqual(1, u)
             XCTAssertEqual("abc", v)
             XCTAssertEqual(1.0, w)
@@ -69,7 +69,7 @@ class WhenTests: XCTestCase {
         let p2 = Promise.value("abc")
         let p3 = Promise.value(1.0)
         let p4 = Promise.value(true)
-        when(fulfilled: p1, p2, p3, p4).done { u, v, w, x in
+        when(thenables: p1, p2, p3, p4).done { u, v, w, x in
             XCTAssertEqual(1, u)
             XCTAssertEqual("abc", v)
             XCTAssertEqual(1.0, w)
@@ -86,7 +86,7 @@ class WhenTests: XCTestCase {
         let p3 = Promise.value(1.0)
         let p4 = Promise.value(true)
         let p5 = Promise.value("a" as Character)
-        when(fulfilled: p1, p2, p3, p4, p5).done { u, v, w, x, y in
+        when(thenables: p1, p2, p3, p4, p5).done { u, v, w, x, y in
             XCTAssertEqual(1, u)
             XCTAssertEqual("abc", v)
             XCTAssertEqual(1.0, w)
@@ -108,19 +108,19 @@ class WhenTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
     }
-    
+
     func testRejected() {
         enum Error: Swift.Error { case dummy }
 
         let e1 = expectation(description: "")
-        let p1 = after(.milliseconds(100)).map{ true }
-        let p2: Promise<Bool> = after(.milliseconds(200)).map{ throw Error.dummy }
+        let p1 = after(.milliseconds(100)).map { true }
+        let p2: Promise<Bool> = after(.milliseconds(200)).map { throw Error.dummy }
         let p3 = Promise.value(false)
-            
-        when(fulfilled: p1, p2, p3).catch { _ in
+
+        when(thenables: p1, p2, p3).catch { _ in
             e1.fulfill()
         }
-        
+
         waitForExpectations(timeout: 1, handler: nil)
     }
 
@@ -143,7 +143,7 @@ class WhenTests: XCTestCase {
         }.silenceWarning()
 
         progress.resignCurrent()
-        
+
         waitForExpectations(timeout: 1, handler: nil)
     }
 
@@ -161,7 +161,7 @@ class WhenTests: XCTestCase {
         let progress = Progress(totalUnitCount: 1)
         progress.becomeCurrent(withPendingUnitCount: 1)
 
-        let promise = when(fulfilled: p1, p2, p3, p4)
+        let promise = when(thenables: p1, p2, p3, p4)
 
         progress.resignCurrent()
 
@@ -196,7 +196,7 @@ class WhenTests: XCTestCase {
         let ex = expectation(description: "")
         let p1 = Promise<Void>(error: Error.test)
         let p2 = after(.milliseconds(100))
-        when(fulfilled: p1, p2).done{ _ in XCTFail() }.catch { error in
+        when(thenables: p1, p2).done { _ in XCTFail() }.catch { error in
             XCTAssertTrue(error as? Error == Error.test)
             ex.fulfill()
         }


### PR DESCRIPTION
Hello.
Thank you for PromiseKit.
Found this test 
```
func testAllSealedRejectedFirstOneRejects() {
    enum Error: Swift.Error {
        case test1
        case test2
        case test3
    }

    let ex = expectation(description: "")
    let p1 = Promise<Void>(error: Error.test1)
    let p2 = Promise<Void>(error: Error.test2)
    let p3 = Promise<Void>(error: Error.test3)

    when(fulfilled: p1, p2, p3).catch { error in
        XCTAssertTrue(error as? Error == Error.test1)
        ex.fulfill()
    }

    waitForExpectations(timeout: 1)
}
```
Which function is calling on `when(fulfilled: p1, p2, p3)`? `func when<U: Thenable>(fulfilled thenables: U...) -> Promise<Void> where U.T == Void` or `func when<U: Thenable, V: Thenable, W: Thenable>(fulfilled pu: U, _ pv: V, _ pw: W) -> Promise<(U.T, V.T, W.T)>`? To avoid possible **"Ambiguous use of 'when(fulfilled:)'"** I offer to use another method signature for some cases. Also see [this issue](https://bugs.swift.org/browse/SR-11572) for more details.