### PR TITLE
refactor(*): Change empty tuples to `Void`

### DIFF
--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -17,7 +17,7 @@ public struct PMKConfiguration {
     /// The closure used to log PromiseKit events.
     /// Not thread safe; change before processing any promises.
     /// - Note: The default handler calls `print()`
-    public var logHandler: (LogEvent) -> () = { event in
+    public var logHandler: (LogEvent) -> Void = { event in
         switch event {
         case .waitOnMainThread:
             print("PromiseKit: warning: `wait()` called on main thread!")

--- a/Tests/A+/2.2.6.swift
+++ b/Tests/A+/2.2.6.swift
@@ -6,7 +6,7 @@ class Test226: XCTestCase {
         describe("2.2.6: `then` may be called multiple times on the same promise.") {
             describe("2.2.6.1: If/when `promise` is fulfilled, all respective `onFulfilled` callbacks must execute in the order of their originating calls to `then`.") {
                 describe("multiple boring fulfillment handlers") {
-                    testFulfilled(withExpectationCount: 4) { promise, exes, sentinel -> () in
+                    testFulfilled(withExpectationCount: 4) { promise, exes, sentinel -> Void in
                         var orderValidator = 0
                         promise.done {
                             XCTAssertEqual($0, sentinel)

--- a/Tests/CorePromise/LoggingTests.swift
+++ b/Tests/CorePromise/LoggingTests.swift
@@ -178,7 +178,7 @@ class LoggingTests: XCTestCase {
     func testPendingGuaranteeDeallocatedIsLogged() {
         
         var logOutput: String? = nil
-        let loggingClosure: (PromiseKit.LogEvent) -> () = { event in
+        let loggingClosure: (PromiseKit.LogEvent) -> Void = { event in
             switch event {
             case .waitOnMainThread, .pendingPromiseDeallocated, .pendingGuaranteeDeallocated:
                 logOutput = "\(event)"


### PR DESCRIPTION
# Description

We have a typealias for empty tuples `Void`. 
This pull-request changes empty tuples `()` to `Void` in return types.

# Motivation and Context

Always used `Void` in return types in this project so I change to recover this in forgotten functions and closures.

PTAL @mxcl 🚀 📱 And thank you for your dedication to the open source. 🙏 