### PR TITLE
Remove unused index var in when.swift

### DIFF
--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -154,14 +154,12 @@ public func when<It: IteratorProtocol>(fulfilled promiseIterator: It, concurrent
         }
         guard shouldDequeue else { return }
 
-        var index: Int!
         var promise: It.Element!
 
         barrier.sync(flags: .barrier) {
             guard let next = generator.next() else { return }
 
             promise = next
-            index = promises.count
 
             pendingPromises += 1
             promises.append(next)


### PR DESCRIPTION
Small PR to remove an unused variable in when.swift that kept showing up in build warnings, that it was written to, but never read.