### PR TITLE
Updated product to be dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let pkg = Package(name: "PromiseKit")
 pkg.products = [
-    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+    .library(name: "PromiseKit", type: .dynamic, targets: ["PromiseKit"]),
 ]
 
 let pmk: Target = .target(name: "PromiseKit")

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let pkg = Package(name: "PromiseKit")
 pkg.products = [
-    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+    .library(name: "PromiseKit", type: .dynamic, targets: ["PromiseKit"]),
 ]
 
 let pmk: Target = .target(name: "PromiseKit")

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -7,7 +7,7 @@ pkg.platforms = [
    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
 ]
 pkg.products = [
-    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+    .library(name: "PromiseKit", type: .dynamic, targets: ["PromiseKit"]),
 ]
 
 let pmk: Target = .target(name: "PromiseKit")


### PR DESCRIPTION
Switched the products from Swift Package Manager to be `dynamic` rather than `static`. 

By default, Swift Package Manager sets this to `static` and can cause linking issues. The specific error I am trying to address is:
> error: Swift package product LIBRARY is linked as a static library by APP and EXTENSION. This will result in duplication of library code.