### PR TITLE
Fixed NSError().isCancelled

### DIFF
--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(StoreKit)
+import StoreKit
+#endif
 
 public enum PMKError: Error {
     /**
@@ -83,12 +86,17 @@ extension Error {
         } catch CocoaError.userCancelled {
             return true
         } catch {
-        #if os(macOS) || os(iOS) || os(tvOS)
-            let pair = { ($0.domain, $0.code) }(error as NSError)
-            return ("SKErrorDomain", 2) == pair
-        #else
+            #if canImport(StoreKit)
+            do {
+                throw self
+            } catch SKError.paymentCancelled {
+                return true
+            } catch {
+                return false
+            }
+            #else
             return false
-        #endif
+            #endif
         }
     }
 }

--- a/Tests/CorePromise/CancellableErrorTests.swift
+++ b/Tests/CorePromise/CancellableErrorTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import PromiseKit
 import XCTest
+#if canImport(StoreKit)
+import StoreKit
+#endif
 
 class CancellationTests: XCTestCase {
     func testCancellation() {
@@ -101,6 +104,13 @@ class CancellationTests: XCTestCase {
         XCTAssertTrue(URLError.cancelled.isCancelled)
         XCTAssertTrue(CocoaError.cancelled.isCancelled)
         XCTAssertFalse(CocoaError(_nsError: NSError(domain: NSCocoaErrorDomain, code: CocoaError.Code.coderInvalidValue.rawValue)).isCancelled)
+        #if canImport(StoreKit)
+        XCTAssertTrue(SKError(.paymentCancelled).isCancelled)
+        XCTAssertFalse(SKError(.paymentInvalid).isCancelled)
+        XCTAssertTrue(NSError(domain: SKErrorDomain, code: SKError.paymentCancelled.rawValue, userInfo: nil).isCancelled)
+        XCTAssertFalse(NSError(domain: "Any other domain", code: SKError.paymentCancelled.rawValue, userInfo: nil).isCancelled)
+        #endif
+        XCTAssertFalse(NSError().isCancelled)
     }
 #endif
 }


### PR DESCRIPTION
Hello.
Thank you for PromiseKit.
In this pull request I fixed #1089.
I know that in https://github.com/mxcl/PromiseKit/commit/4ff9962082349a3dba84617e6e044ccda5cd41fd you mentioned that **SKError still is not a real Error, hard-code these**. However in this pull request all tests are passing, so probably it is fixed now. And I replaced "SKErrorDomain" and 2 with StoreKit's constants.