### PR TITLE
Set iOS 9 as a minimal deployment target

### DIFF
--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let pkg = Package(name: "PromiseKit")
+pkg.platforms = [
+   .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
+]
+pkg.products = [
+    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+]
+
+let pmk: Target = .target(name: "PromiseKit")
+pmk.path = "Sources"
+pmk.exclude = [
+    "AnyPromise.swift",
+    "AnyPromise.m",
+    "PMKCallVariadicBlock.m",
+    "dispatch_promise.m",
+    "join.m",
+    "when.m",
+    "NSMethodSignatureForBlock.m",
+    "after.m",
+    "hang.m",
+    "race.m",
+    "Deprecations.swift",
+    "Info.plist"
+]
+pkg.swiftLanguageVersions = [.v4, .v4_2, .v5]
+pkg.targets = [
+    pmk,
+    .testTarget(name: "A+", dependencies: ["PromiseKit"]),
+    .testTarget(name: "CorePromise", dependencies: ["PromiseKit"], path: "Tests/CorePromise"),
+]


### PR DESCRIPTION
Hey

Xcode 12 doesn't support iOS 8, so there're some annoying warnings:
![image](https://user-images.githubusercontent.com/2575555/95085106-7308af00-0727-11eb-85b7-c9cabb2d637a.png)

What do you think about setting iOS 9 as a min version?