### PR TITLE
Allow resolving Resolver with Swift.Result on Swift 5+

### DIFF
--- a/Sources/Resolver.swift
+++ b/Sources/Resolver.swift
@@ -82,6 +82,18 @@ extension Resolver where T == Void {
 }
 #endif
 
+#if swift(>=5.0)
+extension Resolver {
+    /// Resolves the promise with the provided result
+    public func resolve<E: Error>(_ result: Swift.Result<T, E>) {
+        switch result {
+        case .failure(let error): self.reject(error)
+        case .success(let value): self.fulfill(value)
+        }
+    }
+}
+#endif
+
 public enum Result<T> {
     case fulfilled(T)
     case rejected(Error)

--- a/Tests/CorePromise/XCTestManifests.swift
+++ b/Tests/CorePromise/XCTestManifests.swift
@@ -261,6 +261,8 @@ extension WrapTests {
         ("testNonOptionalFirstParameter", testNonOptionalFirstParameter),
         ("testPendingPromiseDeallocated", testPendingPromiseDeallocated),
         ("testSuccess", testSuccess),
+        ("testSwiftResultError", testSwiftResultError),
+        ("testSwiftResultSuccess", testSwiftResultSuccess),
         ("testVoidCompletionValue", testVoidCompletionValue),
         ("testVoidResolverFulfillAmbiguity", testVoidResolverFulfillAmbiguity),
     ]


### PR DESCRIPTION
This patch allows a `Resolver` to be resolved with a Swift 5+ `Swift.Result`. This is very useful when working with libraries that have adopted the new result class, e.g. Kingfisher:

```swift
Promise {
    KingfisherManager.shared.retrieveImage(with: url, completionHandler: $0.resolve)
}
``` 

This should already work in the PromiseKit 7 alpha, since the internal `Result` case has been removed in favour of using `Swift.Result`. But I think it's nice to get this in on the 6.x release as well since many projects prefer to stay on stable versions, and to ease the transition from 6 -> 7 by allowing one to slowly move things to use `Swift.Result`.

Let me know if there is anything else you need from me in order to land this!