### PR TITLE
doc: update documentation for doubling up Promises

### DIFF
--- a/Documentation/Appendix.md
+++ b/Documentation/Appendix.md
@@ -28,8 +28,10 @@ func toggleNetworkSpinnerWithPromise<T>(funcToCall: () -> Promise<T>) -> Promise
     return firstly {
         setNetworkActivityIndicatorVisible(true)
         return funcToCall()
-    }.always {
-        setNetworkActivityIndicatorVisible(false)
+    }.recover { err -> Promise<T> in
+        return setNetworkActivityIndicatorVisible(false)
+        // or wrap the error with stack
+        // throw OtherError(stack: err)
     }
 }
 ```
@@ -63,7 +65,7 @@ error type for this condition:
 ```swift
 return firstly {
     getItems()
-}.map { items -> [Item]> in
+}.map { items -> [Item] in
     guard !items.isEmpty else {
         throw MyError.emptyItems
     }


### PR DESCRIPTION
In the `Appendix` section, document about `Doubling up Promises` is outdated, a few developers follow the documentation (someone like me) would get stumped,  because they don't know how to wrap a new error while error occured in a Promise, so I update the documentation for it:

- `always` function was deprecated, should use `recover` instead here.
-  could wrap a new error with stack in `recover` function.