### PR TITLE
ObjC AnyPromise and SwiftPackageManager (SPM)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ pmk.exclude = [
 ]
 
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
-pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.dependencies = ["PromiseffKit"]
 pmkObjc.path = "Sources"
 pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [

--- a/Package.swift
+++ b/Package.swift
@@ -4,13 +4,12 @@ import PackageDescription
 
 let pkg = Package(name: "PromiseKit")
 pkg.products = [
-    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+	.library(name: "PromiseKit", targets: ["PromiseKit", "PromiseKitObjC"])
 ]
 
 let pmk: Target = .target(name: "PromiseKit")
 pmk.path = "Sources"
 pmk.exclude = [
-    "AnyPromise.swift",
     "AnyPromise.m",
     "PMKCallVariadicBlock.m",
     "dispatch_promise.m",
@@ -22,9 +21,35 @@ pmk.exclude = [
     "race.m",
     "Deprecations.swift"
 ]
-pkg.swiftLanguageVersions = [3, 4, 5]
+
+let pmkObjc: Target = .target(name: "PromiseKitObjC")
+pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.exclude = [
+	"PMKCallVariadicBlock.m",
+	"after.swift",
+	"AnyPromise.swift",
+	"Box.swift",
+	"Catchable.swift",
+	"Configuration.swift",
+	"CustomStringConvertible.swift",
+	"Deprecations.swift",
+	"Error.swift",
+	"firstly.swift",
+	"Guarantee.swift",
+	"hang.swift",
+	"Info.plist",
+	"LogEvent.swift",
+	"Promise.swift",
+	"race.swift",
+	"Resolver.swift",
+	"Thenable.swift",
+	"when.swift"
+]
+
+pkg.swiftLanguageVersions = [3, 4]
 pkg.targets = [
     pmk,
+	pmkObjc,
     .testTarget(name: "APlus", dependencies: ["PromiseKit"], path: "Tests/A+"),
     .testTarget(name: "CorePromise", dependencies: ["PromiseKit"], path: "Tests/CorePromise"),
 ]

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,8 @@ pmk.exclude = [
 
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
 pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.path = "Sources"
+pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [
 	"PMKCallVariadicBlock.m",
 	"after.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ pmk.exclude = [
 ]
 
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
-pmkObjc.dependencies = ["PromiseffKit"]
+pmkObjc.dependencies = ["PromiseKit"]
 pmkObjc.path = "Sources"
 pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -23,7 +23,7 @@ pmk.exclude = [
 ]
 
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
-pmkObjc.dependencies = ["PromisedKit"]
+pmkObjc.dependencies = ["PromiseKit"]
 pmkObjc.path = "Sources"
 pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -4,27 +4,51 @@ import PackageDescription
 
 let pkg = Package(name: "PromiseKit")
 pkg.products = [
-    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+	.library(name: "PromiseKit", targets: ["PromiseKit", "PromiseKitObjC"])
 ]
 
 let pmk: Target = .target(name: "PromiseKit")
 pmk.path = "Sources"
 pmk.exclude = [
-    "AnyPromise.swift",
-    "AnyPromise.m",
-    "PMKCallVariadicBlock.m",
-    "dispatch_promise.m",
-    "join.m",
-    "when.m",
-    "NSMethodSignatureForBlock.m",
-    "after.m",
-    "hang.m",
-    "race.m",
-    "Deprecations.swift"
+	"AnyPromise.m",
+	"PMKCallVariadicBlock.m",
+	"dispatch_promise.m",
+	"join.m",
+	"when.m",
+	"NSMethodSignatureForBlock.m",
+	"after.m",
+	"hang.m",
+	"race.m",
+	"Deprecations.swift"
+]
+
+let pmkObjc: Target = .target(name: "PromiseKitObjC")
+pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.exclude = [
+	"PMKCallVariadicBlock.m",
+	"after.swift",
+	"AnyPromise.swift",
+	"Box.swift",
+	"Catchable.swift",
+	"Configuration.swift",
+	"CustomStringConvertible.swift",
+	"Deprecations.swift",
+	"Error.swift",
+	"firstly.swift",
+	"Guarantee.swift",
+	"hang.swift",
+	"Info.plist",
+	"LogEvent.swift",
+	"Promise.swift",
+	"race.swift",
+	"Resolver.swift",
+	"Thenable.swift",
+	"when.swift"
 ]
 pkg.swiftLanguageVersions = [.v3, .v4, .v4_2]
 pkg.targets = [
     pmk,
+	pmkObjc,
     .testTarget(name: "APlus", dependencies: ["PromiseKit"], path: "Tests/A+"),
     .testTarget(name: "CorePromise", dependencies: ["PromiseKit"], path: "Tests/CorePromise"),
 ]

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -24,6 +24,8 @@ pmk.exclude = [
 
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
 pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.path = "Sources"
+pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [
 	"PMKCallVariadicBlock.m",
 	"after.swift",
@@ -45,6 +47,7 @@ pmkObjc.exclude = [
 	"Thenable.swift",
 	"when.swift"
 ]
+
 pkg.swiftLanguageVersions = [.v3, .v4, .v4_2]
 pkg.targets = [
     pmk,

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -23,7 +23,7 @@ pmk.exclude = [
 ]
 
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
-pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.dependencies = ["PromisedKit"]
 pmkObjc.path = "Sources"
 pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -25,6 +25,7 @@ pmk.exclude = [
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
 pmkObjc.dependencies = [.target(name: "PromiseKit")]
 pmkObjc.path = "Sources"
+pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [
 	"PMKCallVariadicBlock.m",
 	"after.swift",
@@ -46,6 +47,7 @@ pmkObjc.exclude = [
 	"Thenable.swift",
 	"when.swift"
 ]
+
 pkg.swiftLanguageVersions = [.v4, .v4_2, .v5]
 pkg.targets = [
     pmk,

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -3,31 +3,53 @@
 import PackageDescription
 
 let pkg = Package(name: "PromiseKit")
-pkg.platforms = [
-   .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
-]
 pkg.products = [
-    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+	.library(name: "PromiseKit", targets: ["PromiseKit", "PromiseKitObjC"])
 ]
 
 let pmk: Target = .target(name: "PromiseKit")
 pmk.path = "Sources"
 pmk.exclude = [
-    "AnyPromise.swift",
-    "AnyPromise.m",
-    "PMKCallVariadicBlock.m",
-    "dispatch_promise.m",
-    "join.m",
-    "when.m",
-    "NSMethodSignatureForBlock.m",
-    "after.m",
-    "hang.m",
-    "race.m",
-    "Deprecations.swift"
+	"AnyPromise.m",
+	"PMKCallVariadicBlock.m",
+	"dispatch_promise.m",
+	"join.m",
+	"when.m",
+	"NSMethodSignatureForBlock.m",
+	"after.m",
+	"hang.m",
+	"race.m",
+	"Deprecations.swift"
+]
+
+let pmkObjc: Target = .target(name: "PromiseKitObjC")
+pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.path = "Sources"
+pmkObjc.exclude = [
+	"PMKCallVariadicBlock.m",
+	"after.swift",
+	"AnyPromise.swift",
+	"Box.swift",
+	"Catchable.swift",
+	"Configuration.swift",
+	"CustomStringConvertible.swift",
+	"Deprecations.swift",
+	"Error.swift",
+	"firstly.swift",
+	"Guarantee.swift",
+	"hang.swift",
+	"Info.plist",
+	"LogEvent.swift",
+	"Promise.swift",
+	"race.swift",
+	"Resolver.swift",
+	"Thenable.swift",
+	"when.swift"
 ]
 pkg.swiftLanguageVersions = [.v4, .v4_2, .v5]
 pkg.targets = [
     pmk,
+	pmkObjc,
     .testTarget(name: "APlus", dependencies: ["PromiseKit"], path: "Tests/A+"),
     .testTarget(name: "CorePromise", dependencies: ["PromiseKit"], path: "Tests/CorePromise"),
 ]

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -23,7 +23,7 @@ pmk.exclude = [
 ]
 
 let pmkObjc: Target = .target(name: "PromiseKitObjC")
-pmkObjc.dependencies = [.target(name: "PromiseKit")]
+pmkObjc.dependencies = ["PromiseKit"]
 pmkObjc.path = "Sources"
 pmkObjc.publicHeadersPath = "."
 pmkObjc.exclude = [

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -7,28 +7,55 @@ pkg.platforms = [
    .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
 ]
 pkg.products = [
-    .library(name: "PromiseKit", targets: ["PromiseKit"]),
+	.library(name: "PromiseKit", targets: ["PromiseKit", "PromiseKitObjC"])
 ]
 
 let pmk: Target = .target(name: "PromiseKit")
 pmk.path = "Sources"
 pmk.exclude = [
-    "AnyPromise.swift",
-    "AnyPromise.m",
-    "PMKCallVariadicBlock.m",
-    "dispatch_promise.m",
-    "join.m",
-    "when.m",
-    "NSMethodSignatureForBlock.m",
-    "after.m",
-    "hang.m",
-    "race.m",
-    "Deprecations.swift",
+	"AnyPromise.m",
+	"PMKCallVariadicBlock.m",
+	"dispatch_promise.m",
+	"join.m",
+	"when.m",
+	"NSMethodSignatureForBlock.m",
+	"after.m",
+	"hang.m",
+	"race.m",
+	"Deprecations.swift",
     "Info.plist"
 ]
+
+let pmkObjc: Target = .target(name: "PromiseKitObjC")
+pmkObjc.dependencies = ["PromiseKit"]
+pmkObjc.path = "Sources"
+pmkObjc.publicHeadersPath = "."
+pmkObjc.exclude = [
+	"PMKCallVariadicBlock.m",
+	"after.swift",
+	"AnyPromise.swift",
+	"Box.swift",
+	"Catchable.swift",
+	"Configuration.swift",
+	"CustomStringConvertible.swift",
+	"Deprecations.swift",
+	"Error.swift",
+	"firstly.swift",
+	"Guarantee.swift",
+	"hang.swift",
+	"Info.plist",
+	"LogEvent.swift",
+	"Promise.swift",
+	"race.swift",
+	"Resolver.swift",
+	"Thenable.swift",
+	"when.swift"
+]
+
 pkg.swiftLanguageVersions = [.v4, .v4_2, .v5]
 pkg.targets = [
     pmk,
+	pmkObjc,
     .testTarget(name: "APlus", dependencies: ["PromiseKit"], path: "Tests/A+", exclude: ["README.md"]),
     .testTarget(name: "CorePromise", dependencies: ["PromiseKit"], path: "Tests/CorePromise"),
 ]

--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.version = '6.15.2'
 
   s.source = {
-    :git => "https://github.com/DG0BAB/#{s.name}.git",
+    :git => "https://github.com/mxcl/#{s.name}.git",
     :tag => s.version,
     :submodules => true
   }

--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.version = '6.15.2'
 
   s.source = {
-    :git => "https://github.com/mxcl/#{s.name}.git",
+    :git => "https://github.com/DG0BAB/#{s.name}.git",
     :tag => s.version,
     :submodules => true
   }

--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		632FBBE51F33B338008F8FBB /* CatchableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632FBBE41F33B338008F8FBB /* CatchableTests.swift */; };
 		633027E6203CC0060037E136 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63B0AC571D595E1B00FA21D9 /* PromiseKit.framework */; };
 		6330B5E11F2E991200D60528 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6330B5E01F2E991200D60528 /* Configuration.swift */; };
-		634AAD2B1EAE517C00B17855 /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = 634AAD2A1EAE517C00B17855 /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		635D641D1D59635300BC0AF5 /* PromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635D64081D59635300BC0AF5 /* PromiseTests.swift */; };
 		635D641E1D59635300BC0AF5 /* CancellableErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635D64091D59635300BC0AF5 /* CancellableErrorTests.swift */; };
 		635D64221D59635300BC0AF5 /* ZalgoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635D640D1D59635300BC0AF5 /* ZalgoTests.swift */; };
@@ -60,7 +59,6 @@
 		639BF757203DF03100FA577B /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639BF755203DF02C00FA577B /* Utilities.swift */; };
 		63B0AC7F1D595E6300FA21D9 /* after.m in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC611D595E6300FA21D9 /* after.m */; };
 		63B0AC801D595E6300FA21D9 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC621D595E6300FA21D9 /* after.swift */; };
-		63B0AC811D595E6300FA21D9 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 63B0AC631D595E6300FA21D9 /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63B0AC821D595E6300FA21D9 /* AnyPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC641D595E6300FA21D9 /* AnyPromise.m */; };
 		63B0AC831D595E6300FA21D9 /* AnyPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC651D595E6300FA21D9 /* AnyPromise.swift */; };
 		63B0AC841D595E6300FA21D9 /* AnyPromise+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 63B0AC661D595E6300FA21D9 /* AnyPromise+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -68,7 +66,6 @@
 		63B0AC871D595E6300FA21D9 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC691D595E6300FA21D9 /* Error.swift */; };
 		63B0AC891D595E6300FA21D9 /* hang.m in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC6B1D595E6300FA21D9 /* hang.m */; };
 		63B0AC8B1D595E6300FA21D9 /* join.m in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC6D1D595E6300FA21D9 /* join.m */; };
-		63B0AC931D595E6300FA21D9 /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 63B0AC761D595E6300FA21D9 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		63B0AC991D595E6300FA21D9 /* when.m in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC7C1D595E6300FA21D9 /* when.m */; };
 		63B0AC9A1D595E6300FA21D9 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B0AC7D1D595E6300FA21D9 /* when.swift */; };
 		63B18AEC1F2D205C00B79E37 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B18AEB1F2D205C00B79E37 /* CustomStringConvertible.swift */; };
@@ -80,6 +77,9 @@
 		63CF6D80203CD19200EC8927 /* ThenableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63CF6D7F203CD19200EC8927 /* ThenableTests.swift */; };
 		63D9B2EF203385FD0075C00B /* race.m in Sources */ = {isa = PBXBuildFile; fileRef = 63D9B2EE203385FD0075C00B /* race.m */; };
 		63D9B2F120338D5D0075C00B /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D9B2F020338D5D0075C00B /* Deprecations.swift */; };
+		797714D2260296910076AAD8 /* PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 63B0AC761D595E6300FA21D9 /* PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		797714E52602992E0076AAD8 /* AnyPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 63B0AC631D595E6300FA21D9 /* AnyPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		797714F2260299AA0076AAD8 /* fwd.h in Headers */ = {isa = PBXBuildFile; fileRef = 634AAD2A1EAE517C00B17855 /* fwd.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C013F7382048E3B6006B57B1 /* MockNodeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C013F7372048E3B6006B57B1 /* MockNodeEnvironment.swift */; };
 		C013F73A2049076A006B57B1 /* JSPromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = C013F7392049076A006B57B1 /* JSPromise.swift */; };
 		C013F73C20494291006B57B1 /* JSAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C013F73B20494291006B57B1 /* JSAdapter.swift */; };
@@ -432,6 +432,7 @@
 			isa = PBXGroup;
 			children = (
 				636A29191F1C156B001229C2 /* Promise.swift */,
+				63B0AC651D595E6300FA21D9 /* AnyPromise.swift */,
 				636A29221F1C17A6001229C2 /* Guarantee.swift */,
 				636A29201F1C1716001229C2 /* Thenable.swift */,
 				632FBBE21F33B273008F8FBB /* Catchable.swift */,
@@ -461,7 +462,6 @@
 			isa = PBXGroup;
 			children = (
 				63B0AC641D595E6300FA21D9 /* AnyPromise.m */,
-				63B0AC651D595E6300FA21D9 /* AnyPromise.swift */,
 				63B0AC671D595E6300FA21D9 /* dispatch_promise.m */,
 				630B60C01F2F73B000A1AEFE /* Headers */,
 				630B60BF1F2F739E00A1AEFE /* Features */,
@@ -501,9 +501,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				63B0AC931D595E6300FA21D9 /* PromiseKit.h in Headers */,
-				634AAD2B1EAE517C00B17855 /* fwd.h in Headers */,
-				63B0AC811D595E6300FA21D9 /* AnyPromise.h in Headers */,
+				797714D2260296910076AAD8 /* PromiseKit.h in Headers */,
+				797714E52602992E0076AAD8 /* AnyPromise.h in Headers */,
+				797714F2260299AA0076AAD8 /* fwd.h in Headers */,
 				63B0AC841D595E6300FA21D9 /* AnyPromise+Private.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -741,6 +741,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				63B0AC831D595E6300FA21D9 /* AnyPromise.swift in Sources */,
 				636A29251F1C3089001229C2 /* race.swift in Sources */,
 				63B0AC9A1D595E6300FA21D9 /* when.swift in Sources */,
 				636A29271F1C3927001229C2 /* Resolver.swift in Sources */,
@@ -760,7 +761,6 @@
 				636A291A1F1C156B001229C2 /* Promise.swift in Sources */,
 				63B0AC8B1D595E6300FA21D9 /* join.m in Sources */,
 				63B0AC891D595E6300FA21D9 /* hang.m in Sources */,
-				63B0AC831D595E6300FA21D9 /* AnyPromise.swift in Sources */,
 				63D9B2F120338D5D0075C00B /* Deprecations.swift in Sources */,
 				63B0AC871D595E6300FA21D9 /* Error.swift in Sources */,
 				0CC3AF2B1FCF84F7000E98C9 /* hang.swift in Sources */,

--- a/Sources/AnyPromise+Private.h
+++ b/Sources/AnyPromise+Private.h
@@ -26,7 +26,3 @@
 #import "AnyPromise.h"
 
 @class PMKArray;
-
-@interface AnyPromise ()
-- (void)__pipe:(void(^ __nonnull)(__nullable id))block NS_REFINED_FOR_SWIFT;
-@end

--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -2,15 +2,13 @@
 #import <dispatch/dispatch.h>
 #import <PromiseKit/fwd.h>
 
-/// INTERNAL DO NOT USE
-@class __AnyPromise;
-
 /// Provided to simplify some usage sites
 typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
 
 
 /// An Objective-C implementation of the promise pattern.
-@interface AnyPromise: NSObject
+@interface AnyPromise (ObjC)
+
 
 /**
  Create a new promise that resolves with the provided block.
@@ -33,9 +31,6 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
  */
 + (instancetype __nonnull)promiseWithResolverBlock:(void (^ __nonnull)(__nonnull PMKResolver))resolveBlock NS_REFINED_FOR_SWIFT;
 
-
-/// INTERNAL DO NOT USE
-- (instancetype __nonnull)initWith__D:(__AnyPromise * __nonnull)d;
 
 /**
  Creates a resolved promise.

--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <dispatch/dispatch.h>
-#import <PromiseKit/fwd.h>
+#import <fwd.h>
 
 // Different ways to make AnyPromise available
 //

--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -2,6 +2,27 @@
 #import <dispatch/dispatch.h>
 #import <PromiseKit/fwd.h>
 
+// Different ways to make AnyPromise available
+//
+// Import the Swift-Module if it was created already
+//
+// If building a Swift-Package just import PromiseKit
+//
+// In all other cases AnyPromise is still just a foward
+// declaration and needs to be defined. This is just to
+// silence a compile error which would avoid building
+// the Swift-Module on first builds.
+#if __has_include("PromiseKit-Swift.h")
+	#import "PromiseKit-Swift.h"
+#elif __has_include("PromiseKit/PromiseKit-Swift.h")
+	#import <PromiseKit/PromiseKit-Swift.h>
+#elif SWIFT_PACKAGE
+@import PromiseKit;
+#else
+@interface AnyPromise
+@end
+#endif
+
 /// Provided to simplify some usage sites
 typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
 

--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -12,11 +12,12 @@
 // declaration and needs to be defined. This is just to
 // silence a compile error which would avoid building
 // the Swift-Module on first builds.
+
 #if __has_include("PromiseKit-Swift.h")
 	#import "PromiseKit-Swift.h"
 #elif __has_include("PromiseKit/PromiseKit-Swift.h")
 	#import <PromiseKit/PromiseKit-Swift.h>
-#elif SWIFT_PACKAGE
+#elif SWIFT_PACKAGE && __has_feature(modules)
 @import PromiseKit;
 #else
 @interface AnyPromise

--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -17,7 +17,7 @@
 	#import "PromiseKit-Swift.h"
 #elif __has_include("PromiseKit/PromiseKit-Swift.h")
 	#import <PromiseKit/PromiseKit-Swift.h>
-#elif SWIFT_PACKAGE && __has_feature(modules)
+#elif SWIFT_PACKAGE
 @import PromiseKit;
 #else
 @interface AnyPromise

--- a/Sources/AnyPromise.m
+++ b/Sources/AnyPromise.m
@@ -1,60 +1,34 @@
-#if __has_include("PromiseKit-Swift.h")
-    #import "PromiseKit-Swift.h"
-#else
-    #import <PromiseKit/PromiseKit-Swift.h>
-#endif
 #import "PMKCallVariadicBlock.m"
 #import "AnyPromise+Private.h"
 #import "AnyPromise.h"
 
+
 NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 
-@implementation AnyPromise {
-    __AnyPromise *d;
-}
-
-- (instancetype)initWith__D:(__AnyPromise *)dd {
-    self = [super init];
-    if (self) self->d = dd;
-    return self;
-}
+@implementation AnyPromise (ObjC)
 
 - (instancetype)initWithResolver:(PMKResolver __strong *)resolver {
-    self = [super init];
-    if (self)
-        d = [[__AnyPromise alloc] initWithResolver:^(void (^resolve)(id)) {
+    self = [self initWithResolver_:^(void (^resolve)(id)) {
             *resolver = resolve;
-        }];
+    }];
     return self;
 }
 
 + (instancetype)promiseWithResolverBlock:(void (^)(PMKResolver _Nonnull))resolveBlock {
-    id d = [[__AnyPromise alloc] initWithResolver:resolveBlock];
-    return [[self alloc] initWith__D:d];
+    return [[AnyPromise alloc] initWithResolver_:resolveBlock];
 }
 
 + (instancetype)promiseWithValue:(id)value {
     //TODO provide a more efficient route for sealed promises
-    id d = [[__AnyPromise alloc] initWithResolver:^(void (^resolve)(id)) {
+    return [[AnyPromise alloc] initWithResolver_:^(void (^resolve)(id)) {
         resolve(value);
     }];
-    return [[self alloc] initWith__D:d];
-}
-
-//TODO remove if possible, but used by when.m
-- (void)__pipe:(void (^)(id _Nullable))block {
-    [d __pipe:block];
-}
-
-//NOTE used by AnyPromise.swift
-- (id)__d {
-    return d;
 }
 
 - (AnyPromise *(^)(id))then {
     return ^(id block) {
-        return [self->d __thenOn:dispatch_get_main_queue() execute:^(id obj) {
+        return [self __thenOn:dispatch_get_main_queue() execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -62,7 +36,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(dispatch_queue_t, id))thenOn {
     return ^(dispatch_queue_t queue, id block) {
-        return [self->d __thenOn:queue execute:^(id obj) {
+        return [self __thenOn:queue execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -70,7 +44,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(id))thenInBackground {
     return ^(id block) {
-        return [self->d __thenOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
+        return [self __thenOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -78,7 +52,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(dispatch_queue_t, id))catchOn {
     return ^(dispatch_queue_t q, id block) {
-        return [self->d __catchOn:q execute:^(id obj) {
+        return [self __catchOn:q execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -86,7 +60,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(id))catch {
     return ^(id block) {
-        return [self->d __catchOn:dispatch_get_main_queue() execute:^(id obj) {
+        return [self __catchOn:dispatch_get_main_queue() execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -94,7 +68,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(id))catchInBackground {
     return ^(id block) {
-        return [self->d __catchOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
+        return [self __catchOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -102,26 +76,26 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(dispatch_block_t))ensure {
     return ^(dispatch_block_t block) {
-        return [self->d __ensureOn:dispatch_get_main_queue() execute:block];
+        return [self __ensureOn:dispatch_get_main_queue() execute:block];
     };
 }
 
 - (AnyPromise *(^)(dispatch_queue_t, dispatch_block_t))ensureOn {
     return ^(dispatch_queue_t queue, dispatch_block_t block) {
-        return [self->d __ensureOn:queue execute:block];
+        return [self __ensureOn:queue execute:block];
     };
 }
 
 - (id)wait {
-    return [d __wait];
+    return [self __wait];
 }
 
 - (BOOL)pending {
-    return [[d valueForKey:@"__pending"] boolValue];
+    return [[self valueForKey:@"__pending"] boolValue];
 }
 
 - (BOOL)rejected {
-    return IsError([d __value]);
+    return IsError([self __value]);
 }
 
 - (BOOL)fulfilled {
@@ -129,7 +103,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 }
 
 - (id)value {
-    id obj = [d __value];
+    id obj = [self __value];
 
     if ([obj isKindOfClass:[PMKArray class]]) {
         return obj[0];

--- a/Sources/AnyPromise.swift
+++ b/Sources/AnyPromise.swift
@@ -10,7 +10,7 @@ import Foundation
 */
 @objc public class AnyPromise: NSObject {
 
-    fileprivate let box: Box<Any?>
+    let box: Box<Any?>
 
     @objc public init(resolver_ body: (@escaping (Any?) -> Void) -> Void) {
         box = EmptyBox<Any?>()

--- a/Sources/AnyPromise.swift
+++ b/Sources/AnyPromise.swift
@@ -1,21 +1,23 @@
 import Foundation
 
 /**
- __AnyPromise is an implementation detail.
+ Swift implementation for the `AnyPromise`
 
- Because of how ObjC/Swift compatibility work we have to compose our AnyPromise
- with this internal object, however this is still part of the public interface.
+ Because of how ObjC/Swift compatibility work we have to compose our `AnyPromise`
+ with this internal object. This is soley used for bridging `Promise` between
+ Swift/ObjC and vice versa. However this is still part of the public interface.
  Sadly. Please don’t use it.
 */
-@objc(__AnyPromise) public class __AnyPromise: NSObject {
+@objc public class AnyPromise: NSObject {
+
     fileprivate let box: Box<Any?>
 
-    @objc public init(resolver body: (@escaping (Any?) -> Void) -> Void) {
+    @objc public init(resolver_ body: (@escaping (Any?) -> Void) -> Void) {
         box = EmptyBox<Any?>()
         super.init()
         body {
             if let p = $0 as? AnyPromise {
-                p.d.__pipe(self.box.seal)
+                p.__pipe(self.box.seal)
             } else {
                 self.box.seal($0)
             }
@@ -23,7 +25,7 @@ import Foundation
     }
 
     @objc public func __thenOn(_ q: DispatchQueue, execute: @escaping (Any?) -> Any?) -> AnyPromise {
-        return AnyPromise(__D: __AnyPromise(resolver: { resolve in
+        return AnyPromise(resolver_: { resolve in
             self.__pipe { obj in
                 if !(obj is NSError) {
                     q.async {
@@ -33,11 +35,11 @@ import Foundation
                     resolve(obj)
                 }
             }
-        }))
+        })
     }
 
     @objc public func __catchOn(_ q: DispatchQueue, execute: @escaping (Any?) -> Any?) -> AnyPromise {
-        return AnyPromise(__D: __AnyPromise(resolver: { resolve in
+        return AnyPromise(resolver_: { resolve in
             self.__pipe { obj in
                 if obj is NSError {
                     q.async {
@@ -47,27 +49,27 @@ import Foundation
                     resolve(obj)
                 }
             }
-        }))
+        })
     }
 
     @objc public func __ensureOn(_ q: DispatchQueue, execute: @escaping () -> Void) -> AnyPromise {
-        return AnyPromise(__D: __AnyPromise(resolver: { resolve in
+        return AnyPromise(resolver_: { resolve in
             self.__pipe { obj in
                 q.async {
                     execute()
                     resolve(obj)
                 }
             }
-        }))
+        })
     }
 
     @objc public func __wait() -> Any? {
         if Thread.isMainThread {
             conf.logHandler(.waitOnMainThread)
         }
-        
+
         var result = __value
-        
+
         if result == nil {
             let group = DispatchGroup()
             group.enter()
@@ -77,10 +79,10 @@ import Foundation
             }
             group.wait()
         }
-        
+
         return result
     }
- 
+
     /// Internal, do not use! Some behaviors undefined.
     @objc public func __pipe(_ to: @escaping (Any?) -> Void) {
         let to = { (obj: Any?) -> Void in
@@ -130,7 +132,7 @@ extension AnyPromise: Thenable, CatchMixin {
 
     /// - Returns: A new `AnyPromise` bound to a `Promise<Any>`.
     public convenience init<U: Thenable>(_ bridge: U) {
-        self.init(__D: __AnyPromise(resolver: { resolve in
+        self.init(resolver_: { resolve in
             bridge.pipe {
                 switch $0 {
                 case .rejected(let error):
@@ -139,7 +141,7 @@ extension AnyPromise: Thenable, CatchMixin {
                     resolve(value)
                 }
             }
-        }))
+        })
     }
 
     public func pipe(to body: @escaping (Result<Any?>) -> Void) {
@@ -175,14 +177,6 @@ extension AnyPromise: Thenable, CatchMixin {
         }
     }
 
-    fileprivate var d: __AnyPromise {
-        return value(forKey: "__d") as! __AnyPromise
-    }
-
-    var box: Box<Any?> {
-        return d.box
-    }
-
     public var result: Result<Any?>? {
         guard let value = __value else {
             return nil
@@ -207,7 +201,7 @@ public extension Promise where T == Any? {
     }
 }
 #else
-extension AnyPromise {
+public extension AnyPromise {
     public func asPromise() -> Promise<Any?> {
         return Promise(.pending, resolver: { resolve in
             pipe { result in

--- a/Sources/PromiseKit.h
+++ b/Sources/PromiseKit.h
@@ -1,5 +1,5 @@
-#import <PromiseKit/fwd.h>
-#import <PromiseKit/AnyPromise.h>
+#import <fwd.h>
+#import <AnyPromise.h>
 
 #import <Foundation/NSObjCRuntime.h>  // `FOUNDATION_EXPORT`
 

--- a/Sources/fwd.h
+++ b/Sources/fwd.h
@@ -1,7 +1,7 @@
 #import <Foundation/NSDate.h>
 #import <dispatch/dispatch.h>
 
-@import PromiseKit;
+@class AnyPromise;
 
 extern NSString * __nonnull const PMKErrorDomain;
 

--- a/Sources/fwd.h
+++ b/Sources/fwd.h
@@ -1,7 +1,8 @@
 #import <Foundation/NSDate.h>
 #import <dispatch/dispatch.h>
 
-@class AnyPromise;
+@import PromiseKit;
+
 extern NSString * __nonnull const PMKErrorDomain;
 
 #define PMKFailingPromiseIndexKey @"PMKFailingPromiseIndexKey"
@@ -103,11 +104,11 @@ AnyPromise *__nonnull PMKJoin(NSArray * __nonnull promises) NS_REFINED_FOR_SWIFT
 
 /**
  Literally hangs this thread until the promise has resolved.
- 
+
  Do not use hang… unless you are testing, playing or debugging.
- 
+
  If you use it in production code I will literally and honestly cry like a child.
- 
+
  @return The resolved value of the promise.
 
  @warning T SAFE. IT IS NOT SAFE. IT IS NOT SAFE. IT IS NOT SAFE. IT IS NO

--- a/Tests/Bridging/Infrastructure.swift
+++ b/Tests/Bridging/Infrastructure.swift
@@ -1,3 +1,4 @@
+import Foundation
 import PromiseKit
 
 // for BridgingTests.m


### PR DESCRIPTION
This PR makes `AnyPromise` available to Objective-C and Swift code when used with SPM.

To achieve this, the PromiseKit package now consists of two targets. PromiseKit and PromiseKitObjC. The existence of PromiseKitObjC is almost irrelevant to the client because a simple `#import PromiseKit.h` can be used in Objective-C files to get access to `AnyPromise`. If the client wants to use modules, `@import PromiseKitObjC;` must be used. 

`AnyPromise` is now defined in Swift and uses the `@objc` attribute. It's made accessible to Objective-C, by adding the category `@interface AnyPromise (ObjC)` to it. All ObjC functionality defined in this category, delegates to the Swift `AnyPromise`. 

Additional changes to other files were necessary to make everything work in the PromiseKit Xcode Project and while build as a SwiftPackage. All tests succeeded in the Xcode Project.