### PR TITLE
Change variable `root` to constant to avoid warnings.

### DIFF
--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -138,8 +138,8 @@ public func when<It: IteratorProtocol>(fulfilled promiseIterator: It, concurrent
         return Promise(error: PMKError.badInput)
     }
 
+    let root = Promise<[It.Element.T]>.pending()
     var generator = promiseIterator
-    var root = Promise<[It.Element.T]>.pending()
     var pendingPromises = 0
     var promises: [It.Element] = []
 


### PR DESCRIPTION
## Description

There is a warning related to the `root` variable in `when.swift`. So I've change it to constant.