### PR TITLE
Removed Swift Compiler Warnings

### DIFF
--- a/Sources/Thenable.swift
+++ b/Sources/Thenable.swift
@@ -1,7 +1,7 @@
 import Dispatch
 
 /// Thenable represents an asynchronous operation that can be chained.
-public protocol Thenable: class {
+public protocol Thenable: AnyObject {
     /// The type of the wrapped value
     associatedtype T
 

--- a/Sources/when.swift
+++ b/Sources/when.swift
@@ -139,7 +139,7 @@ public func when<It: IteratorProtocol>(fulfilled promiseIterator: It, concurrent
     }
 
     var generator = promiseIterator
-    var root = Promise<[It.Element.T]>.pending()
+    let root = Promise<[It.Element.T]>.pending()
     var pendingPromises = 0
     var promises: [It.Element] = []
 


### PR DESCRIPTION
- Using AnyObject instead of class in Thenable protocol
- Changed root variable to a let