### PR TITLE
Fix body() being called on a background queue

### DIFF
--- a/Documentation/CommonPatterns.md
+++ b/Documentation/CommonPatterns.md
@@ -310,7 +310,7 @@ func attempt<T>(maximumRetryCount: Int = 3, delayBeforeRetry: DispatchTimeInterv
         attempts += 1
         return body().recover { error -> Promise<T> in
             guard attempts < maximumRetryCount else { throw error }
-            return after(delayBeforeRetry).then(on: nil, attempt)
+            return after(delayBeforeRetry).then(attempt)
         }
     }
     return attempt()


### PR DESCRIPTION
The previous version of the code would call body() on a background thread if it was retried. This caused a hard to debug bug in one of my apps.