### PR TITLE
Fixed isCancelled crash

### DIFF
--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -89,8 +89,9 @@ extension Error {
             return true
         } catch {
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-            let domain = (error as AnyObject).value(forKey: "domain") as? String
-            let code = (error as AnyObject).value(forKey: "code") as? Int
+            let error = error as NSError
+            let domain = error.domain
+            let code = error.code
             return ("SKErrorDomain", 2) == (domain, code)
         #else
             return false

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -87,15 +87,16 @@ extension Error {
             return true
         } catch CocoaError.userCancelled {
             return true
+        } catch let error as NSError {
+            #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+                let domain = error.domain
+                let code = error.code
+                return ("SKErrorDomain", 2) == (domain, code)
+            #else
+                return false
+            #endif
         } catch {
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-            let error = error as NSError
-            let domain = error.domain
-            let code = error.code
-            return ("SKErrorDomain", 2) == (domain, code)
-        #else
             return false
-        #endif
         }
     }
 }

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -95,8 +95,6 @@ extension Error {
             #else
                 return false
             #endif
-        } catch {
-            return false
         }
     }
 }

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -95,6 +95,8 @@ extension Error {
             #else
                 return false
             #endif
+        } catch {
+            return false
         }
     }
 }

--- a/Tests/CorePromise/CancellableErrorTests.swift
+++ b/Tests/CorePromise/CancellableErrorTests.swift
@@ -121,6 +121,17 @@ class CancellationTests: XCTestCase {
       #endif
     }
 
+    func testBridgeToNSError() {
+        // Swift.Error types must be cast to NSError for the bridging to occur.
+        // The below would throw an expection about an invalid selector without a cast:
+        // `(error as AnyObject).value(forKey: "domain")`
+        // This simply checks to make sure `isCancelled` is not making that mistake.
+
+        class TestingError: Error { }
+
+        XCTAssertFalse(TestingError().isCancelled)
+    }
+
 #if swift(>=3.2)
     func testIsCancelled() {
         XCTAssertTrue(PMKError.cancelled.isCancelled)

--- a/Tests/CorePromise/XCTestManifests.swift
+++ b/Tests/CorePromise/XCTestManifests.swift
@@ -17,6 +17,7 @@ extension CancellationTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__CancellationTests = [
+        ("testBridgeToNSError", testBridgeToNSError),
         ("testCancellation", testCancellation),
         ("testDoesntCrashSwift", testDoesntCrashSwift),
         ("testFoundationBridging1", testFoundationBridging1),


### PR DESCRIPTION
`Swift.Error` was not being bridged properly to `NSError`, resulting in a selector not found exception when "domain" and "code" values were accessed via a cast only to `AnyObject`. This casts as `NSError` so that the bridging provided by the compiler works as expected.

I wasn't able to determine if this is a change in the recent Swift release or some other more subtle change, but this approach is clear and works well in my testing.

I was able to reproduce the crash this fixes with a simple playground containing:
``` swift 
import Foundation

class TestingError: Error { }

let error = TestingError()

let domain = (error as? AnyObject)?.value(forKey: "domain") as? String
```