### PR TITLE
ensureInBackground + QOS_CLASS_UNSPECIFIED

### DIFF
--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -98,6 +98,13 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
 */
 - (AnyPromise * __nonnull (^ __nonnull)(id __nonnull))then NS_REFINED_FOR_SWIFT;
 
+/**
+ The provided block is executed on the dispatch queue of your choice when the receiver is fulfilled.
+
+ @see then
+ @see thenInBackground
+*/
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))thenOn NS_REFINED_FOR_SWIFT;
 
 /**
  The provided block is executed on the default queue when the receiver is fulfilled.
@@ -108,14 +115,6 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
  @see thenOn
 */
 - (AnyPromise * __nonnull(^ __nonnull)(id __nonnull))thenInBackground NS_REFINED_FOR_SWIFT;
-
-/**
- The provided block is executed on the dispatch queue of your choice when the receiver is fulfilled.
-
- @see then
- @see thenInBackground
-*/
-- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))thenOn NS_REFINED_FOR_SWIFT;
 
 #ifndef __cplusplus
 /**
@@ -140,6 +139,20 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
 
  Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
 
+ The provided block always runs on queue provided.
+
+ @warning *Note* Cancellation errors are not caught.
+
+ @see catch
+ @see catchInBackground
+ */
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))catchOn NS_REFINED_FOR_SWIFT;
+
+/**
+ The provided block is executed when the receiver is rejected.
+
+ Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
+
  The provided block always runs on the global background queue.
 
  @warning *Note* Cancellation errors are not caught.
@@ -150,21 +163,6 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
  @see catchOn
  */
 - (AnyPromise * __nonnull(^ __nonnull)(id __nonnull))catchInBackground NS_REFINED_FOR_SWIFT;
-
-
-/**
- The provided block is executed when the receiver is rejected.
-
- Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
-
- The provided block always runs on queue provided.
-
- @warning *Note* Cancellation errors are not caught.
-
- @see catch
- @see catchInBackground
- */
-- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))catchOn NS_REFINED_FOR_SWIFT;
 
 /**
  The provided block is executed when the receiver is resolved.
@@ -181,6 +179,13 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
  @see ensure
  */
 - (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, dispatch_block_t __nonnull))ensureOn NS_REFINED_FOR_SWIFT;
+
+/**
+ The provided block is executed on the global background queue when the receiver is resolved.
+
+ @see ensure
+ */
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_block_t __nonnull))ensureInBackground NS_REFINED_FOR_SWIFT;
 
 /**
  Wait until the promise is resolved.

--- a/Sources/AnyPromise.h
+++ b/Sources/AnyPromise.h
@@ -98,13 +98,6 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
 */
 - (AnyPromise * __nonnull (^ __nonnull)(id __nonnull))then NS_REFINED_FOR_SWIFT;
 
-/**
- The provided block is executed on the dispatch queue of your choice when the receiver is fulfilled.
-
- @see then
- @see thenInBackground
-*/
-- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))thenOn NS_REFINED_FOR_SWIFT;
 
 /**
  The provided block is executed on the default queue when the receiver is fulfilled.
@@ -115,6 +108,14 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
  @see thenOn
 */
 - (AnyPromise * __nonnull(^ __nonnull)(id __nonnull))thenInBackground NS_REFINED_FOR_SWIFT;
+
+/**
+ The provided block is executed on the dispatch queue of your choice when the receiver is fulfilled.
+
+ @see then
+ @see thenInBackground
+*/
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))thenOn NS_REFINED_FOR_SWIFT;
 
 #ifndef __cplusplus
 /**
@@ -139,20 +140,6 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
 
  Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
 
- The provided block always runs on queue provided.
-
- @warning *Note* Cancellation errors are not caught.
-
- @see catch
- @see catchInBackground
- */
-- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))catchOn NS_REFINED_FOR_SWIFT;
-
-/**
- The provided block is executed when the receiver is rejected.
-
- Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
-
  The provided block always runs on the global background queue.
 
  @warning *Note* Cancellation errors are not caught.
@@ -163,6 +150,21 @@ typedef void (^PMKResolver)(id __nullable) NS_REFINED_FOR_SWIFT;
  @see catchOn
  */
 - (AnyPromise * __nonnull(^ __nonnull)(id __nonnull))catchInBackground NS_REFINED_FOR_SWIFT;
+
+
+/**
+ The provided block is executed when the receiver is rejected.
+
+ Provide a block of form `^(NSError *){}` or simply `^{}`. The parameter has type `id` to give you the freedom to choose either.
+
+ The provided block always runs on queue provided.
+
+ @warning *Note* Cancellation errors are not caught.
+
+ @see catch
+ @see catchInBackground
+ */
+- (AnyPromise * __nonnull(^ __nonnull)(dispatch_queue_t __nonnull, id __nonnull))catchOn NS_REFINED_FOR_SWIFT;
 
 /**
  The provided block is executed when the receiver is resolved.

--- a/Sources/AnyPromise.m
+++ b/Sources/AnyPromise.m
@@ -70,15 +70,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(id))thenInBackground {
     return ^(id block) {
-        return [self->d __thenOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
-            return PMKCallVariadicBlock(block, obj);
-        }];
-    };
-}
-
-- (AnyPromise *(^)(dispatch_queue_t, id))catchOn {
-    return ^(dispatch_queue_t q, id block) {
-        return [self->d __catchOn:q execute:^(id obj) {
+        return [self->d __thenOn:dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0) execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -92,9 +84,17 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
     };
 }
 
+- (AnyPromise *(^)(dispatch_queue_t, id))catchOn {
+    return ^(dispatch_queue_t q, id block) {
+        return [self->d __catchOn:q execute:^(id obj) {
+            return PMKCallVariadicBlock(block, obj);
+        }];
+    };
+}
+
 - (AnyPromise *(^)(id))catchInBackground {
     return ^(id block) {
-        return [self->d __catchOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
+        return [self->d __catchOn:dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0) execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -109,6 +109,12 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 - (AnyPromise *(^)(dispatch_queue_t, dispatch_block_t))ensureOn {
     return ^(dispatch_queue_t queue, dispatch_block_t block) {
         return [self->d __ensureOn:queue execute:block];
+    };
+}
+
+- (AnyPromise *(^)(dispatch_block_t))ensureInBackground {
+    return ^(dispatch_block_t block) {
+        return [self->d __ensureOn:dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0) execute:block];
     };
 }
 

--- a/Sources/AnyPromise.m
+++ b/Sources/AnyPromise.m
@@ -70,15 +70,7 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
 
 - (AnyPromise *(^)(id))thenInBackground {
     return ^(id block) {
-        return [self->d __thenOn:dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0) execute:^(id obj) {
-            return PMKCallVariadicBlock(block, obj);
-        }];
-    };
-}
-
-- (AnyPromise *(^)(id))catch {
-    return ^(id block) {
-        return [self->d __catchOn:dispatch_get_main_queue() execute:^(id obj) {
+        return [self->d __thenOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };
@@ -92,9 +84,17 @@ NSString *const PMKErrorDomain = @"PMKErrorDomain";
     };
 }
 
+- (AnyPromise *(^)(id))catch {
+    return ^(id block) {
+        return [self->d __catchOn:dispatch_get_main_queue() execute:^(id obj) {
+            return PMKCallVariadicBlock(block, obj);
+        }];
+    };
+}
+
 - (AnyPromise *(^)(id))catchInBackground {
     return ^(id block) {
-        return [self->d __catchOn:dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0) execute:^(id obj) {
+        return [self->d __catchOn:dispatch_get_global_queue(0, 0) execute:^(id obj) {
             return PMKCallVariadicBlock(block, obj);
         }];
     };

--- a/Sources/after.m
+++ b/Sources/after.m
@@ -7,7 +7,7 @@
 AnyPromise *PMKAfter(NSTimeInterval duration) {
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(duration * NSEC_PER_SEC));
-        dispatch_after(time, dispatch_get_global_queue(0, 0), ^{
+        dispatch_after(time, dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0), ^{
             resolve(@(duration));
         });
     }];

--- a/Sources/dispatch_promise.m
+++ b/Sources/dispatch_promise.m
@@ -6,5 +6,5 @@ AnyPromise *dispatch_promise_on(dispatch_queue_t queue, id block) {
 }
 
 AnyPromise *dispatch_promise(id block) {
-    return dispatch_promise_on(dispatch_get_global_queue(0, 0), block);
+    return dispatch_promise_on(dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0), block);
 }

--- a/Tests/CoreObjC/AnyPromiseTests.m
+++ b/Tests/CoreObjC/AnyPromiseTests.m
@@ -23,7 +23,7 @@ static inline AnyPromise *rejectLater() {
 
 static inline AnyPromise *fulfillLater() {
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
-        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0), ^{
             resolve(@1);
         });
     }];
@@ -797,7 +797,13 @@ static inline AnyPromise *fulfillLater() {
 
 - (void)testEnsureOn {
     id ex = [self expectationWithDescription:@""];
-    PMKAfter(0.1).ensureOn(dispatch_get_global_queue(0, 0), ^{ [ex fulfill]; });
+    PMKAfter(0.1).ensureOn(dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0), ^{ [ex fulfill]; });
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testEnsureInBackground {
+    id ex = [self expectationWithDescription:@""];
+    PMKAfter(0.1).ensureInBackground(^{ [ex fulfill]; });
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 


### PR DESCRIPTION
Hello.
Thank you for PromiseKit.
Add `ensureInBackground`. Use `QOS_CLASS_UNSPECIFIED` instead of 0 where applicable. Methods ordering `something` -> `somethingOn` -> `somethingInBackground`.