### PR TITLE
Add reference Async+ for Swift 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ For Carthage, SwiftPM, Accio, etc., or for instructions when using older Swifts 
 [Carthage](https://github.com/Carthage/Carthage) or
 [Accio](https://github.com/JamitLabs/Accio).
 
+# PromiseKit and Swift 5.5+ Async/Await 
+
+As of Swift 5.5, the Swift language now offers support for [built-in concurrency with async / await](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html).  See [Async+](https://github.com/async-plus/async-plus) for a port of PromiseKit's most useful patterns to this new paradigm.
+
 # Professionally Supported PromiseKit is Now Available
 
 TideLift gives software development teams a single source for purchasing


### PR DESCRIPTION
I've been a long-time user and fan of PromiseKit, but recently started using Swift's async/await for my new projects.  I felt some of the best parts of PromiseKit were missing though (e.g. `recover`, `ensure`), so I created [Async+](https://github.com/async-plus/async-plus) to try to remedy this.

@mxcl mentioned I should create a PR to promote this solution.  I didn't quite know:

1) Where to put the reference to Async+. In this initial PR I have it in the README, but I also looked at putting it in the FAQ. I also didn't know where exactly to put it in the README, so I opted for the section after `Getting Started`, but feel free to request whichever location is best.

2) How/if to reference that Async+ is newly-created and ongoing in development.  I am using it for my own small projects, but have not released any major apps with it yet.  Alternatively I could say something along the lines of: <br /><br />"As of Swift 5.5, the Swift language now offers support for [built-in concurrency with async / await](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html).  There is an ongoing development effort to port PromiseKit's most useful patterns to this new paradigm: see [Async+](https://github.com/async-plus/async-plus)."

Thanks!

Gabe
