### PR TITLE
prevent dependency cycles by creating headers before compiling sources

### DIFF
--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -586,9 +586,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 63B0AC5F1D595E1B00FA21D9 /* Build configuration list for PBXNativeTarget "PromiseKit" */;
 			buildPhases = (
+				63B0AC541D595E1B00FA21D9 /* Headers */,
 				63B0AC521D595E1B00FA21D9 /* Sources */,
 				63B0AC531D595E1B00FA21D9 /* Frameworks */,
-				63B0AC541D595E1B00FA21D9 /* Headers */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
Creating the headers before compiling the sources prevents potential dependency cycles. 

This started happening for us after updating xcode to version 13.3. I double checked this and there obviously is no dependency from PromiseKit to our libraries, so the error doesn't make much sense to me. Changing the order of the build phases reliably fixes the problem.

![Screenshot 2022-03-25 at 16 47 06](https://user-images.githubusercontent.com/5617793/160156654-12513007-052c-484e-ad1c-89514974e6c9.png)
