### PR TITLE
Bumping iOS deployment target to 11.0 (10.0 after discussion)

### DIFF
--- a/.github/workflows/ci-podspec.yml
+++ b/.github/workflows/ci-podspec.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - run: pod lib lint --fail-fast
+    - run: pod lib lint --fail-fast --allow-warnings

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - run: pod lib lint --fail-fast
+    - run: pod lib lint --fail-fast --allow-warnings
 
   create-release:
     runs-on: ubuntu-latest

--- a/PromiseKit.podspec
+++ b/PromiseKit.podspec
@@ -24,10 +24,10 @@ Pod::Spec.new do |s|
   # CocoaPods requires us to specify the root deployment targets
   # even though for us it is nonsense. Our root spec has no
   # sources.
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.10'
-  s.watchos.deployment_target = '2.0'
-  s.tvos.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.13'
+  s.watchos.deployment_target = '4.0'
+  s.tvos.deployment_target = '10.0'
 
   s.pod_target_xcconfig = {
     'OTHER_SWIFT_FLAGS' => '-DPMKCocoaPods',
@@ -38,19 +38,8 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/Accounts/Sources/*.plist'
     ss.ios.frameworks = ss.osx.frameworks = 'Accounts'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-  end
-
-  s.subspec 'Alamofire' do |ss|
-    ss.source_files = 'Extensions/Alamofire/Sources/**/*'
-    ss.exclude_files = 'Extensions/Alamofire/Sources/*.plist'
-    ss.dependency 'Alamofire', '~> 4.0'
-    ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.11'
-    ss.watchos.deployment_target = '2.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
   end
 
   s.subspec 'AddressBook' do |ss|
@@ -58,7 +47,7 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/AddressBook/Sources/*.plist'
     ss.ios.frameworks = 'AddressBook'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
+    ss.ios.deployment_target = '10.0'
   end
 
   s.subspec 'AssetsLibrary' do |ss|
@@ -66,7 +55,7 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/AssetsLibrary/Sources/*.plist'
     ss.ios.frameworks = 'AssetsLibrary'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
+    ss.ios.deployment_target = '10.0'
   end
 
   s.subspec 'AVFoundation' do |ss|
@@ -74,18 +63,7 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/AVFoundation/Sources/*.plist'
     ss.ios.frameworks = 'AVFoundation'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-  end
-
-  s.subspec 'Bolts' do |ss|
-    ss.source_files = 'Extensions/Bolts/Sources/**/*'
-    ss.exclude_files = 'Extensions/Bolts/Sources/*.plist'
-    ss.dependency 'PromiseKit/CorePromise'
-    ss.dependency 'Bolts', '~> 1.9.0'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.watchos.deployment_target = '2.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
   end
 
   s.subspec 'CloudKit' do |ss|
@@ -94,9 +72,9 @@ Pod::Spec.new do |s|
     ss.frameworks = 'CloudKit'
     ss.dependency 'PromiseKit/CorePromise'
     ss.ios.deployment_target = '10.0'
-    ss.osx.deployment_target = '10.12'
+    ss.osx.deployment_target = '10.13'
     ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '3.0'
+    ss.watchos.deployment_target = '4.0'
   end
 
   s.subspec 'CoreBluetooth' do |ss|
@@ -104,9 +82,9 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/CoreBluetooth/Sources/*.plist'
     ss.ios.frameworks = ss.osx.frameworks = ss.tvos.frameworks = 'CoreBluetooth'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'CorePromise' do |ss|
@@ -122,10 +100,10 @@ Pod::Spec.new do |s|
     ss.preserve_paths = 'Sources/AnyPromise+Private.h', 'Sources/PMKCallVariadicBlock.m', 'Sources/NSMethodSignatureForBlock.m'
     ss.frameworks = 'Foundation'
 
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.watchos.deployment_target = '2.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.watchos.deployment_target = '4.0'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'CoreLocation' do |ss|
@@ -135,10 +113,10 @@ Pod::Spec.new do |s|
     ss.dependency 'PromiseKit/CorePromise'
     ss.frameworks = 'CoreLocation'
 
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.watchos.deployment_target = '3.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.watchos.deployment_target = '4.0'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'EventKit' do |ss|
@@ -147,9 +125,9 @@ Pod::Spec.new do |s|
     ss.ios.frameworks = ss.osx.frameworks = ss.watchos.frameworks = 'EventKit'
     ss.dependency 'PromiseKit/CorePromise'
 
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.watchos.deployment_target = '2.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.watchos.deployment_target = '4.0'
   end
 
   s.subspec 'Foundation' do |ss|
@@ -157,10 +135,10 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/Foundation/Sources/*.plist'
     ss.dependency 'PromiseKit/CorePromise'
     ss.frameworks = 'Foundation'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.watchos.deployment_target = '2.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.watchos.deployment_target = '4.0'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'HealthKit' do |ss|
@@ -168,8 +146,8 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/HealthKit/Sources/*.plist'
     ss.dependency 'PromiseKit/CorePromise'
     ss.frameworks = 'HealthKit'
-    ss.ios.deployment_target = '9.0'
-    ss.watchos.deployment_target = '2.0'
+    ss.ios.deployment_target = '10.0'
+    ss.watchos.deployment_target = '4.0'
   end
 
   s.subspec 'HomeKit' do |ss|
@@ -177,9 +155,9 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/HomeKit/Sources/*.plist'
     ss.dependency 'PromiseKit/CorePromise'
     ss.frameworks = 'HomeKit'
-    ss.ios.deployment_target = '8.0'
-    ss.watchos.deployment_target = '3.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.watchos.deployment_target = '4.0'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'MapKit' do |ss|
@@ -187,10 +165,10 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/MapKit/Sources/*.plist'
     ss.ios.frameworks = ss.osx.frameworks = ss.tvos.frameworks = 'MapKit'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.watchos.deployment_target = '2.0'
-    ss.tvos.deployment_target = '9.2'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.watchos.deployment_target = '4.0'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'MessageUI' do |ss|
@@ -198,18 +176,7 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/MessagesUI/Sources/*.plist'
     ss.ios.frameworks = 'MessageUI'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-  end
-
-  s.subspec 'OMGHTTPURLRQ' do |ss|
-    ss.source_files = 'Extensions/OMGHTTPURLRQ/Sources/**/*'
-    ss.exclude_files = 'Extensions/OMGHTTPURLRQ/Sources/*.plist'
-    ss.dependency 'PromiseKit/Foundation'
-    ss.dependency 'OMGHTTPURLRQ', '~> 3.2'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.watchos.deployment_target = '2.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
   end
 
   s.subspec 'Photos' do |ss|
@@ -218,7 +185,7 @@ Pod::Spec.new do |s|
     ss.ios.frameworks = ss.tvos.frameworks = ss.osx.frameworks = 'Photos'
     ss.dependency 'PromiseKit/CorePromise'
 
-    ss.ios.deployment_target = '8.0'
+    ss.ios.deployment_target = '10.0'
     ss.osx.deployment_target = '10.13'
     ss.tvos.deployment_target = '10.0'
   end
@@ -228,9 +195,9 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/QuartzCore/Sources/*.plist'
     ss.osx.frameworks = ss.ios.frameworks = ss.tvos.frameworks = 'QuartzCore'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'Social' do |ss|
@@ -239,8 +206,8 @@ Pod::Spec.new do |s|
     ss.osx.source_files = Dir['Extensions/Social/Sources/*'] - ['Categories/Social/Sources/*SLComposeViewController+Promise.swift']
     ss.ios.frameworks = ss.osx.frameworks = 'Social'
     ss.dependency 'PromiseKit/Foundation'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
   end
 
   s.subspec 'StoreKit' do |ss|
@@ -248,9 +215,9 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/StoreKit/Sources/*.plist'
     ss.ios.frameworks = ss.osx.frameworks = ss.tvos.frameworks = 'StoreKit'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'SystemConfiguration' do |ss|
@@ -258,9 +225,9 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/SystemConfiguration/Sources/*.plist'
     ss.ios.frameworks = ss.osx.frameworks = ss.tvos.frameworks = 'SystemConfiguration'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.13'
+    ss.tvos.deployment_target = '10.0'
   end
 
   picker_cc = 'Extensions/UIKit/Sources/UIImagePickerController+Promise.swift'
@@ -270,8 +237,8 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/UIKit/Sources/*.plist'
     ss.tvos.frameworks = ss.ios.frameworks = 'UIKit'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.tvos.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
+    ss.tvos.deployment_target = '10.0'
   end
 
   s.subspec 'UIImagePickerController' do |ss|
@@ -288,7 +255,7 @@ Pod::Spec.new do |s|
     ss.ios.frameworks = 'UIKit'
     ss.ios.xcconfig = { "GCC_PREPROCESSOR_DEFINITIONS" => '$(inherited) PMKImagePickerController=1' }
     ss.dependency 'PromiseKit/UIKit'
-    ss.ios.deployment_target = '8.0'
+    ss.ios.deployment_target = '10.0'
   end
 
   s.subspec 'WatchConnectivity' do |ss|
@@ -296,7 +263,7 @@ Pod::Spec.new do |s|
     ss.exclude_files = 'Extensions/WatchConnectivity/Sources/*.plist'
     ss.ios.frameworks = ss.watchos.frameworks = 'WatchConnectivity'
     ss.dependency 'PromiseKit/CorePromise'
-    ss.ios.deployment_target = '8.0'
-    ss.watchos.deployment_target = '2.0'
+    ss.ios.deployment_target = '10.0'
+    ss.watchos.deployment_target = '4.0'
   end
 end

--- a/PromiseKit.xcodeproj/project.pbxproj
+++ b/PromiseKit.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		085B96BE21A9B37C00E5E22F /* LogEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LogEvent.swift; path = Sources/LogEvent.swift; sourceTree = "<group>"; };
 		0C42F3191FCF86240051309C /* HangTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HangTests.swift; sourceTree = "<group>"; };
 		0CC3AF2A1FCF84F7000E98C9 /* hang.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = hang.swift; path = Sources/hang.swift; sourceTree = "<group>"; };
+		1F1DCDF72A27AB6400E7A16B /* PromiseKit.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = PromiseKit.podspec; sourceTree = "<group>"; };
 		49A5584B1DC5172F00E4D01B /* ResolverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResolverTests.swift; sourceTree = "<group>"; };
 		630019221D596292003B4E30 /* PMKCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PMKCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		630A8051203CEF6800D25F23 /* AnyPromiseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AnyPromiseTests.m; sourceTree = "<group>"; };
@@ -182,7 +183,6 @@
 		635893921D5BE4E000F14B55 /* PromiseKit.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = PromiseKit.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		635893941D5BE4F900F14B55 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		635893951D5BE4F900F14B55 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		635893961D5BE4F900F14B55 /* PromiseKit.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = PromiseKit.podspec; path = .github/PromiseKit.podspec; sourceTree = "<group>"; };
 		635893971D5BE4F900F14B55 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		635D64081D59635300BC0AF5 /* PromiseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseTests.swift; sourceTree = "<group>"; };
 		635D64091D59635300BC0AF5 /* CancellableErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CancellableErrorTests.swift; sourceTree = "<group>"; };
@@ -397,7 +397,7 @@
 				63B0AC6C1D595E6300FA21D9 /* Info.plist */,
 				635893941D5BE4F900F14B55 /* LICENSE */,
 				635893951D5BE4F900F14B55 /* Package.swift */,
-				635893961D5BE4F900F14B55 /* PromiseKit.podspec */,
+				1F1DCDF72A27AB6400E7A16B /* PromiseKit.podspec */,
 			);
 			name = "…";
 			sourceTree = "<group>";
@@ -946,7 +946,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 6.22.1;
+				CURRENT_PROJECT_VERSION = 6.23.0;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1008,7 +1008,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 6.22.1;
+				CURRENT_PROJECT_VERSION = 6.23.0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;

--- a/Tests/Bridging/Infrastructure.m
+++ b/Tests/Bridging/Infrastructure.m
@@ -2,15 +2,15 @@
 @import PromiseKit;
 #import "Infrastructure.h"
 
-AnyPromise *PMKDummyAnyPromise_YES() {
+AnyPromise *PMKDummyAnyPromise_YES(void) {
     return [AnyPromise promiseWithValue:@YES];
 }
 
-AnyPromise *PMKDummyAnyPromise_Manifold() {
+AnyPromise *PMKDummyAnyPromise_Manifold(void) {
     return [AnyPromise promiseWithValue:PMKManifold(@YES, @NO, @NO)];
 }
 
-AnyPromise *PMKDummyAnyPromise_Error() {
+AnyPromise *PMKDummyAnyPromise_Error(void) {
     return [AnyPromise promiseWithValue:[NSError errorWithDomain:@"a" code:1 userInfo:nil]];
 }
 
@@ -28,7 +28,7 @@ AnyPromise *PMKDummyAnyPromise_Error() {
 
 #import "PMKBridgeTests-Swift.h"
 
-AnyPromise *testCase626() {
+AnyPromise *testCase626(void) {
     return PMKWhen(@[[TestPromise626 promise], [TestPromise626 promise]]).then(^(id value){
         NSLog(@"Success: %@", value);
     }).catch(^(NSError *error) {

--- a/Tests/CoreObjC/AnyPromiseTests.m
+++ b/Tests/CoreObjC/AnyPromiseTests.m
@@ -7,11 +7,11 @@ static inline NSError *dummyWithCode(NSInteger code) {
     return [NSError errorWithDomain:PMKTestErrorDomain code:rand() userInfo:@{NSLocalizedDescriptionKey: @(code).stringValue}];
 }
 
-static inline NSError *dummy() {
+static inline NSError *dummy(void) {
     return dummyWithCode(rand());
 }
 
-static inline AnyPromise *rejectLater() {
+static inline AnyPromise *rejectLater(void) {
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -21,7 +21,7 @@ static inline AnyPromise *rejectLater() {
     }];
 }
 
-static inline AnyPromise *fulfillLater() {
+static inline AnyPromise *fulfillLater(void) {
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_UNSPECIFIED, 0), ^{
             resolve(@1);

--- a/Tests/CorePromise/ThenableTests.swift
+++ b/Tests/CorePromise/ThenableTests.swift
@@ -200,11 +200,13 @@ class ThenableTests: XCTestCase {
     }
 
     func testLastValueForEmpty() {
-        XCTAssertTrue(Promise.value([]).lastValue.isRejected)
+        let values = [String]()
+        XCTAssertTrue(Promise.value(values).lastValue.isRejected)
     }
 
     func testFirstValueForEmpty() {
-        XCTAssertTrue(Promise.value([]).firstValue.isRejected)
+        let values = [String]()
+        XCTAssertTrue(Promise.value(values).firstValue.isRejected)
     }
 
     func testThenOffRejected() {


### PR DESCRIPTION
## What changes

* Bumping iOS deployment target to `11.0`
* Also osx to `10.13`, tvos to `11.0` and watchos to `4.0`
* Fixed some warnings due to the bump
* Bumped version to `6.23.0` (confirm me if I should do it or not, I can revert if needed)

## Why do we need this PR

This PR fixes the issue reported on https://github.com/mxcl/PromiseKit/issues/1317, while using Xcode `14.3` to validate the podspec.

Every pod that depends on `PromiseKit/CorePromise` will fail to lint due to what is being explained here https://github.com/mxcl/PromiseKit/issues/1308#issuecomment-1490190549.

**TL;DR**
_Apple has stopped shipping libarclite_iphoneos.a separately [1](https://developer.apple.com/forums/thread/725300)_

As https://github.com/mxcl/PromiseKit/pull/1311 only fixes the xcodeproj, this PR fixes the podspec.

### Implications

With this change it means that consumers need a minimum deployment target of `11.0`, but this will enable future Xcode versions since `14.3`.